### PR TITLE
move routingKey, deliveryTag to headers, keep msg unaltered

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Returns a reference to a queue. The options are
 
 An easy subscription command. It works like this
 
-    q.subscribe(function (message) {
-      puts('Got a message with routing key ' + message._routingKey);
+    q.subscribe(function (message, headers) {
+      puts('Got a message with routing key ' + headers.routingKey);
     });
 
 It will automatically acknowledge receipt of each message.

--- a/amqp.js
+++ b/amqp.js
@@ -1449,10 +1449,10 @@ Queue.prototype.subscribe = function (/* options, messageListener */) {
         json = { data: b, contentType: m.contentType };
       }
 
-      json._routingKey = m.routingKey;
-      json._deliveryTag = m.deliveryTag;
-
-      var headers = {};
+      var headers = {
+          routingKey: m.routingKey,
+          deliveryTag : m.deliveryTag
+      };
       for (var i in this.headers) {
         if(this.headers.hasOwnProperty(i)) {
           if(this.headers[i] instanceof Buffer)

--- a/test/test-default-exchange.js
+++ b/test/test-default-exchange.js
@@ -21,9 +21,9 @@ connection.addListener('ready', function () {
         }, 1000);
       });
       
-      q.subscribe(function (msg) { // register consumer
+      q.subscribe(function (msg, headers) { // register consumer
         recvCount++;
-        switch (msg._routingKey) {
+        switch (headers.routingKey) {
           case 'message.msg1':
             assert.equal(1, msg.one);
             assert.equal(2, msg.two);
@@ -35,7 +35,7 @@ connection.addListener('ready', function () {
             break;
 
           default:
-            throw new Error('unexpected routing key: ' + msg._routingKey);
+            throw new Error('unexpected routing key: ' + headers.routingKey);
         }
       })
     });

--- a/test/test-ex-and-q-deletions.js
+++ b/test/test-ex-and-q-deletions.js
@@ -38,12 +38,12 @@ connection.addListener('ready', function () {
             }, 1000);
           });
           
-          q1.subscribe(function (m) {
-            assert.equal('node-consumer-1', m._routingKey);
+          q1.subscribe(function (m, h) {
+            assert.equal('node-consumer-1', h.routingKey);
             recvCount++;
           });
-          q2.subscribe(function (m) {
-            assert.equal('node-consumer-2', m._routingKey);
+          q2.subscribe(function (m, h) {
+            assert.equal('node-consumer-2', h.routingKey);
             recvCount++;
           })
         });

--- a/test/test-json.js
+++ b/test/test-json.js
@@ -10,36 +10,37 @@ connection.addListener('ready', function () {
 
   var q = connection.queue('node-json-queue', function() {
 
+    var origMessage1 = {two:2, one:1},
+        origMessage2 = {foo:'bar', hello: 'world'},
+        origMessage3 = {coffee:'caf\u00E9', tea: 'th\u00E9'};
+
     q.bind(exchange, "*");
   
-    q.subscribe(function (json) {
+    q.subscribe(function (json, headers) {
       recvCount++;
   
-      switch (json._routingKey) {
+      switch (headers.routingKey) {
         case 'message.json1':
-          assert.equal(1, json.one);
-          assert.equal(2, json.two);
+          assert.deepEqual(origMessage1, json);
           break;
   
         case 'message.json2':
-          assert.equal('world', json.hello);
-          assert.equal('bar', json.foo);
+          assert.deepEqual(origMessage2, json);
           break;
   
         case 'message.json3':
-          assert.equal('caf\u00E9', json.coffee);
-          assert.equal('th\u00E9', json.tea);
+          assert.deepEqual(origMessage3, json);
           break;
   
         default:
-          throw new Error('unexpected routing key: ' + json._routingKey);
+          throw new Error('unexpected routing key: ' + headers.routingKey);
       }
     })
     .addCallback(function () {
       puts("publishing 3 json messages");
-      exchange.publish('message.json1', {two:2, one:1});
-      exchange.publish('message.json2', {foo:'bar', hello: 'world'}, {contentType: 'application/json'});
-      exchange.publish('message.json3', {coffee:'caf\u00E9', tea: 'th\u00E9'}, {contentType: 'application/json'});
+      exchange.publish('message.json1', origMessage1);
+      exchange.publish('message.json2', origMessage2, {contentType: 'application/json'});
+      exchange.publish('message.json3', origMessage3, {contentType: 'application/json'});
   
       setTimeout(function () {
         // wait one second to receive the message, then quit


### PR DESCRIPTION
My previous pullreq ry/node-amqp#18 went unnoticed by Ryan, so here is another attempt. BTW: great to have You on board Theo!

In the meantime 45c1dbe6 added headers to the callback of subscribe, very similar to my last approach.
Still the library modifies json payloads, which imho is a bad thing: Having to clean up messages after using a library is silly and a bit annoying.
The attached pullrequest moves _routingkey and _deliveryTag into the headers - still not optimal, but I wanted to keep the api change small. Separating even further (body, properties like routingKey and then headers) would probably be cleaner but may be considered overkill by some.

What do You think? I'm happy to prepare a another patch based on feedback.
  bkw
