### PR TITLE
Fix handling of empty queue names

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -1178,7 +1178,6 @@ Connection.prototype.queue = function (name /* options, openCallback */) {
 
   var q = new Queue(this, channel, name, options, callback);
   this.channels[channel] = q;
-  this.queues[name] = q;
   return q;
 };
 

--- a/test/test-declare-queue.js
+++ b/test/test-declare-queue.js
@@ -1,0 +1,18 @@
+require('./harness');
+
+connection.addListener('ready', function() {
+  puts("connected to " + connection.serverProperties.product);
+  
+  connection.exchange('test-exchange', {type: 'topic'}, function(exchange) {
+    var namedQueue = connection.queue('test_queue', function(queue) {
+      assert.ok(connection.queues['test_queue'] != null, 'Queue reference not saved in queue array');
+      
+      var q = connection.queue('', function(queue) {
+        assert.ok(connection.queues[''] == null, 'Queue saved with empty string');
+        assert.ok(connection.queues[queue.name] != null, 'Queue not saved with real name');
+        puts("All tests passed");
+        connection.end();
+      });
+    });
+  });
+});


### PR DESCRIPTION
exchange.queue will return the same queue every time it is called with an empty queue name in the same process. One probably wants a new queue every time this is called with an empty queue name.
