### PR TITLE
Support connection URLs as per the AMQP Ruby gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The options object has the these defaults:
 
 All of these can be passed in a single URL of the form
 
-    amqp[s]://[[user:password@]hostname[:port]/vhost
+    amqp[s]://[user:password@]hostname[:port][/vhost]
 
 Note that the vhost must be URL-encoded and appear as the only segment
 of the path, i.e., there is only the leading slash; leaving the path
@@ -68,7 +68,10 @@ be used (it could also be supplied as the path `/%2f`).
 This URL is supplied as the field `url` in the options; for example
 
     var conn =
-      amqp.createConnection({url: "amqp://guest:guest@localhost:5672/%2f"});
+      amqp.createConnection({url: "amqp://guest:guest@localhost:5672"});
+
+Options provided as individual fields will override values given in
+the URL.
 
 After a connection is established the `'connect'` event is fired as it is
 with any `net.Connection` instance. AMQP requires a 7-way handshake which

--- a/amqp.js
+++ b/amqp.js
@@ -880,7 +880,7 @@ function urlOptions(connectionString) {
   }
   opts.ssl = ('amqps' === scheme);
   opts.host = url.hostname;
-  opts.port = url.port || defaultPorts[url.scheme]
+  opts.port = url.port || defaultPorts[scheme]
   if (url.auth) {
     var auth = url.auth.split(':');
     auth[0] && (opts.login = auth[0]);
@@ -901,8 +901,8 @@ exports.createConnection = function (options) {
 
 Connection.prototype.setOptions = function (options) {
   var o  = {};
-  mixin(o, defaultOptions, options || {});
-  if (o['url']) mixin(o, urlOptions(o['url']));
+  urlo = (options && options.url) ? urlOptions(options.url) : {};
+  mixin(o, defaultOptions, urlo, options || {});
   this.options = o;
 };
 


### PR DESCRIPTION
The format is documented here:

http://rdoc.info/github/ruby-amqp/amqp/master/file/docs/ConnectingToTheBroker.textile#Using_connection_strings

It's rather handy if your app needs to be supplied connection details as an environment variable, e.g..
