### PR TITLE
Add support for `prefetchCount` option for `Queue.subscribeRaw`

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -1381,6 +1381,15 @@ Queue.prototype.subscribeRaw = function (/* options, messageListener */) {
     mixin(options, arguments[0]);
   }
 
+  if (options.prefetchCount) {
+    self.connection._sendMethod(self.channel, methods.basicQos,
+        { reserved1: 0
+        , prefetchSize: 0
+        , prefetchCount: options.prefetchCount
+        , global: false
+        });
+  }
+
   return this._taskPush(methods.basicConsumeOk, function () {
     self.connection._sendMethod(self.channel, methods.basicConsume,
         { reserved1: 0


### PR DESCRIPTION
This patch makes `Queue.subscribeRaw` also a call to `basic.qos` in order to establish the number of prefetched messages. (Without this event driven benefits of NodeJS are unused as we won't have more than one single outstanding message to handle.)

P.S.: The patch I've made I've only tested in my particular context, and I hope doesn't break anything. (It's been made ontop of `v0.0.7`, but I think it could also apply successfully ontop of `v0.1.0`.)
