### PR TITLE
JSON error handling.

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -1492,7 +1492,13 @@ Queue.prototype.subscribe = function (/* options, messageListener */) {
     m.addListener('end', function () {
       var json, deliveryInfo = {}, msgProperties = classes[60].fields;
       if (isJSON) {
-        json = JSON.parse(b);
+        try {
+          json = JSON.parse(b);
+        } catch (e) {
+          json = null;
+          deliveryInfo.parseError = e;
+          deliveryInfo.rawData = b;
+        }
       } else {
         json = { data: b, contentType: m.contentType };
       }


### PR DESCRIPTION
Yield a `null` value message, add the parse error to the `deliveryInfo` as `parseError`, also expose `rawData` containing the parsed data.

Continues from #20.
