### PR TITLE
Shut up node 0.6

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -1,5 +1,5 @@
 var events = require('events'),
-    sys = require('sys'),
+    util = require('util'),
     net = require('net'),
     protocol,
     jspack = require('./jspack').jspack,
@@ -67,7 +67,7 @@ function mixin () {
 
 var debugLevel = process.env['NODE_DEBUG_AMQP'] ? 1 : 0;
 function debug (x) {
-  if (debugLevel > 0) sys.error(x + '\n');
+  if (debugLevel > 0) console.error(x + '\n');
 }
 
 
@@ -858,7 +858,7 @@ function Connection (connectionArgs, options) {
     parser = null;
   });
 }
-sys.inherits(Connection, net.Stream);
+util.inherits(Connection, net.Stream);
 exports.Connection = Connection;
 
 
@@ -995,7 +995,7 @@ Connection.prototype._onMethod = function (channel, method, args) {
       var e = new Error(args.replyText);
       e.code = args.replyCode;
       if (!this.listeners('close').length) {
-        sys.puts('Unhandled connection error: ' + args.replyText);
+        console.log('Unhandled connection error: ' + args.replyText);
       }
       this.destroy(e);
       break;
@@ -1286,7 +1286,7 @@ function Message (queue, args) {
       }
   }
 }
-sys.inherits(Message, events.EventEmitter);
+util.inherits(Message, events.EventEmitter);
 
 
 // Acknowledge recept of message.
@@ -1312,7 +1312,7 @@ function Channel (connection, channel) {
 
   this.connection._sendMethod(channel, methods.channelOpen, {reserved1: ""});
 }
-sys.inherits(Channel, events.EventEmitter);
+util.inherits(Channel, events.EventEmitter);
 
 
 Channel.prototype._taskPush = function (reply, cb) {
@@ -1397,7 +1397,7 @@ function Queue (connection, channel, name, options, callback) {
 
   this._openCallback = callback;
 }
-sys.inherits(Queue, Channel);
+util.inherits(Queue, Channel);
 
 Queue.prototype.subscribeRaw = function (/* options, messageListener */) {
   var self = this;
@@ -1688,7 +1688,7 @@ Queue.prototype._onMethod = function (channel, method, args) {
       break;
 
     case methods.basicConsumeOk:
-      debug('basicConsumeOk', sys.inspect(args, null));
+      debug('basicConsumeOk', util.inspect(args, null));
       break;
 
     case methods.queueBindOk:
@@ -1753,7 +1753,7 @@ function Exchange (connection, channel, name, options, openCallback) {
   this.options = options || { autoDelete: true};
   this._openCallback = openCallback;
 }
-sys.inherits(Exchange, Channel);
+util.inherits(Exchange, Channel);
 
 
 

--- a/promise.js
+++ b/promise.js
@@ -1,5 +1,5 @@
 var events = require('events');
-var inherits = require('sys').inherits;
+var inherits = require('util').inherits;
 
 exports.Promise = function () {
   events.EventEmitter.call(this);

--- a/test.js
+++ b/test.js
@@ -1,4 +1,3 @@
-var sys =  require('sys');
 var amqp = require('./amqp');
 
 
@@ -9,35 +8,35 @@ connection.addListener('close', function (e) {
   if (e) {
     throw e;
   } else {
-    sys.puts('connection closed.');
+    console.log('connection closed.');
   }
 });
 
 
 connection.addListener('ready', function () {
-  sys.puts("connected to " + connection.serverProperties.product);
+  console.log("connected to " + connection.serverProperties.product);
 
   var exchange = connection.exchange('clock', {type: 'fanout'});
 
   var q = connection.queue('my-events-receiver');
 
   q.bind(exchange, "*").addCallback(function () {
-    sys.puts("publishing message");
+    console.log("publishing message");
     exchange.publish("message.json", {hello: 'world', foo: 'bar'});
     exchange.publish("message.text", 'hello world', {contentType: 'text/plain'});
   });
 
   q.subscribe(function (m) {
-    sys.puts("--- Message (" + m.deliveryTag + ", '" + m.routingKey + "') ---");
-    sys.puts("--- contentType: " + m.contentType);
+    console.log("--- Message (" + m.deliveryTag + ", '" + m.routingKey + "') ---");
+    console.log("--- contentType: " + m.contentType);
 
     m.addListener('data', function (d) {
-      sys.puts(d);
+      console.log(d);
     });
 
     m.addListener('end', function () {
       m.acknowledge();
-      sys.puts("--- END (" + m.deliveryTag + ", '" + m.routingKey + "') ---");
+      console.log("--- END (" + m.deliveryTag + ", '" + m.routingKey + "') ---");
     });
   });
 });

--- a/test/harness.js
+++ b/test/harness.js
@@ -1,5 +1,5 @@
-global.sys =  require('sys');
-puts = sys.puts;
+global.util =  require('util');
+puts = console.log;
 global.assert =  require('assert');
 global.amqp = require('../amqp');
 
@@ -28,6 +28,6 @@ global.errorCallback = function(e) {
 global.connection.addListener('error', global.errorCallback);
 
 global.connection.addListener('close', function (e) {
-  sys.puts('connection closed.');
+  console.log('connection closed.');
 });
 

--- a/test/test-buffer.js
+++ b/test/test-buffer.js
@@ -20,7 +20,7 @@ connection.addListener('ready', function () {
         m.acknowledge();
         switch (m.routingKey) {
           case 'message.bin1':
-            assert.equal(sys.inspect(body), sys.inspect(data));
+            assert.equal(util.inspect(body), util.inspect(data));
             break;
 
           default:

--- a/util/delete-exchange.js
+++ b/util/delete-exchange.js
@@ -1,8 +1,7 @@
-sys = require('sys');
 amqp = require('../amqp');
 
 var name = process.argv[2];
-sys.puts("exchange: " + name);
+console.log("exchange: " + name);
 
 var creds =
   { host:     process.env['AMQP_HOST']      || 'localhost'
@@ -18,10 +17,10 @@ connection.addListener('error', function (e) {
 });
 
 connection.addListener('ready', function () {
-  sys.puts("Connected");
+  console.log("Connected");
   var e = connection.exchange(name);
   e.destroy().addCallback(function () {
-    sys.puts('exchange destroyed.');
+    console.log('exchange destroyed.');
     connection.close();
   });
 });

--- a/util/delete-queue.js
+++ b/util/delete-queue.js
@@ -1,8 +1,7 @@
-sys = require('sys');
 amqp = require('../amqp');
 
 var name = process.argv[2];
-sys.puts("exchange: " + name);
+console.log("exchange: " + name);
 
 var creds =
   { host:     process.env['AMQP_HOST']      || 'localhost'
@@ -18,10 +17,10 @@ connection.addListener('error', function (e) {
 });
 
 connection.addListener('ready', function () {
-  sys.puts("Connected");
+  console.log("Connected");
   var q = connection.queue(name);
   q.destroy().addCallback(function () {
-    sys.puts('queue destroyed.');
+    console.log('queue destroyed.');
     connection.close();
   });
 });


### PR DESCRIPTION
Node from version 0.6 complains, when you use sys module, it emits this:

The "sys" module is now called "util". It should have a similar interface.

This should shut it up, I hope I did not forget anything. It runs for me, but we do not use all the functions in our project, so some more testing by someone should probably happen.
