### PR TITLE
Fix issue 65: Get arguments to copy in the right order and update frameBuffer.used

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -166,7 +166,8 @@ function AMQPParser (version, type) {
   function frame(data) {
     var fb = frameBuffer;
     var needed = fb.length - fb.used;
-    data.copy(fb, 0, fb.used, fb.length);
+    data.copy(fb, fb.used, 0, data.length);
+    fb.used += data.length;
     if (data.length > needed) {
       return frameEnd(data.slice(needed));
     }

--- a/test/test-large-body.js
+++ b/test/test-large-body.js
@@ -1,0 +1,50 @@
+// This effectively tests that a frame that takes more than one packet
+// ('data' event) is parsed correctly.
+// https://github.com/postwait/node-amqp/issues/65
+
+require('./harness');
+
+var recvCount = 0;
+var body = new Buffer(100 * 1024);
+
+connection.addListener('ready', function () {
+  puts("connected to " + connection.serverProperties.product);
+
+  connection.exchange('node-simple-fanout', {type: 'fanout'}, function(exchange) {
+      connection.queue('node-simple-queue', function(q) {
+        q.bind(exchange, "*")
+        q.on('queueBindOk', function() {
+          q.on('basicConsumeOk', function () {
+            puts("publishing message");
+            exchange.publish("message.text", body, {contentType: 'application/octet-stream'});
+
+            setTimeout(function () {
+              // wait one second to receive the message, then quit
+              connection.end();
+            }, 1000);
+          });
+
+          q.subscribeRaw(function (m) {
+            puts("--- Message (" + m.deliveryTag + ", '" + m.routingKey + "') ---");
+            puts("--- contentType: " + m.contentType);
+
+            assert.equal('application/octet-stream', m.contentType);
+
+            var chunks = [];
+            m.addListener('data', function (d) { chunks.push(d.toString()); });
+
+            m.addListener('end', function () {
+              recvCount++;
+              assert.equal(body.toString(), chunks.join(' '));
+              m.acknowledge();
+            });
+          });
+        });
+      });
+  });
+});
+
+
+process.addListener('exit', function () {
+  assert.equal(1, recvCount);
+});


### PR DESCRIPTION
The first bug only manifests with frames that must be sent over multiple packets; otherwise, a new frame buffer is cons'ed anyway. The second bug means that message bodies sent over more than one data packet were junk, since they were copied over the existing frame data; but worse, that frames never ended, since the number of data remaining for the frame is calculated from frameBuffer.used.
