### PR TITLE
quick fix for issue #65

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -166,7 +166,8 @@ function AMQPParser (version, type) {
   function frame(data) {
     var fb = frameBuffer;
     var needed = fb.length - fb.used;
-    data.copy(fb, fb.used, 0, data.length);
+    var sourceEnd = (fb.length > data.length) ? data.length : fb.length;
+    data.copy(fb, fb.used, 0, sourceEnd);
     fb.used += data.length;
     if (data.length > needed) {
       return frameEnd(data.slice(needed));


### PR DESCRIPTION
At data.copy(), sourceEnd was sometimes bigger than data.length which caused the error. This makes sure sourceEnd does not exceed data.length. Fixed the problem for me.
