### PR TITLE
AMQP connection refused. In case the AMQP server is not installed

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -843,6 +843,11 @@ function Connection (connectionArgs, options, readyCallback) {
     // state.
     parser = null;
   });
+  
+  // in case of connection refused error
+  self.addListener('error', function(e){
+    self.end();
+  });
 }
 util.inherits(Connection, net.Stream);
 exports.Connection = Connection;


### PR DESCRIPTION
If try with out installing any AMQP Server, node crashes with the following error.

Error: ECONNREFUSED, Connection refused
