### PR TITLE
Send CloseOK, when receiving channel.close from the server. 

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -1476,6 +1476,10 @@ function Channel (connection, channel) {
 }
 util.inherits(Channel, events.EventEmitter);
 
+Channel.prototype.closeOK = function() {
+    this.connection._sendMethod(this.channel, methods.channelCloseOk, {reserved1: ""});
+}
+
 Channel.prototype.reconnect = function () {
   this.connection._sendMethod(this.channel, methods.channelOpen, {reserved1: ""});
 };
@@ -1943,6 +1947,7 @@ Queue.prototype._onMethod = function (channel, method, args) {
 
     case methods.channelClose:
       this.state = "closed";
+      this.closeOK();
       this.connection.queueClosed(this.name);
       var e = new Error(args.replyText);
       e.code = args.replyCode;
@@ -2087,6 +2092,7 @@ Exchange.prototype._onMethod = function (channel, method, args) {
 
     case methods.channelClose:
       this.state = "closed";
+      this.closeOK();
       this.connection.exchangeClosed(this.name);
       var e = new Error(args.replyText);
       e.code = args.replyCode;


### PR DESCRIPTION
RabbitMQ will not close a channel that has errored until the client acknowledges the error with a channel.CloseOK response.

This was leading to, a leaking of channels whenever there was an error. 
