### PR TITLE
Fixes memory leak for confirmed messages

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -2186,9 +2186,11 @@ Exchange.prototype.publish = function (routingKey, data, options, callback) {
     self._unAcked[self._sequence] = task
     self._sequence++
 
-    if(callback != null){ 
-      task.once('ack',   function(){task.removeAllListeners();callback(false)}); 
-      this.once('error', function(){task.removeAllListeners();callback(true)});
+    if(callback != null){
+      var errorCallback = function(){task.removeAllListeners();callback(true)};
+      var exchange = this;
+      task.once('ack',   function(){exchange.removeListener('error', errorCallback); task.removeAllListeners();callback(false)}); 
+      this.once('error', errorCallback);
     }
   }
 


### PR DESCRIPTION
I played around with confirmation of messages published to an exchange. Since every message subscribes to `error` on the `exchange`, the maxListener limit is hit almost immediately.

This fix removes the error-callback for acknowledged messages from the `exchange`. One does still need to call `setMaxListeners()` on the `exchange` to match the number of expected unconfirmed messages.
