### PR TITLE
Fixes handling of empty messages

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -2002,6 +2002,10 @@ Queue.prototype._onContentHeader = function (channel, classInfo, weight, propert
   this.currentMessage.size = size;
 
   this.emit('rawMessage', this.currentMessage);
+  if (size === 0) {
+    // If the message has no body, directly emit 'end'
+    this.currentMessage.emit('end');
+  }
 };
 
 Queue.prototype._onContent = function (channel, data) {

--- a/test/test-receive-empty-messages.js
+++ b/test/test-receive-empty-messages.js
@@ -1,0 +1,26 @@
+require('./harness');
+
+var timeout = null;
+connection.addListener('ready', function () {
+  var exc = connection.exchange('node-json-exchange');
+  
+  connection.queue('node-json-queue', function(q) {
+    q.bind('node-json-exchange', '*');
+
+    q.subscribe(function (json, headers, deliveryInfo) {
+      clearTimeout(timeout);
+      connection.end();
+    }).addCallback(function () {
+      puts("Publishing one empty message.");
+      exc.publish('node-json-queue', '');
+    });
+  });
+});
+
+timeout = setTimeout(function() {
+  puts("ERROR: Timeout occured!!!!!!!");
+  connection.end();
+  assert.ok(1, 2);
+}, 5000);
+
+


### PR DESCRIPTION
It looks like the `Queue._onContent` callback is not executed, if a message has an empty body (size 0).

This fix emits the 'end' event directly, if the provided size of a new message is zero.
