### PR TITLE
Enable consumeBasic exclusive option through subscribe() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,13 @@ thus adopting the parent connection's values (which default to false).
 Setting these to true provide backward compability for older
 applications.
 
+The 'exclusive' option will subscribe to the queue in exclusive mode. Only one
+subscriber is allowed at a time, and subsequent attempts to subscribe to the
+same queue will result in an exception. This option differes from the exclusive
+option passed when creating in a queue in that the queue itself is not exclusive,
+only the consumers. This means that long lived durable queues can be used
+as exclusive queues.
+
 This method will emit `'basicQosOk'` when ready.
 
 

--- a/amqp.js
+++ b/amqp.js
@@ -1638,11 +1638,16 @@ Queue.prototype.subscribe = function (/* options, messageListener */) {
       options.deliveryTagInPayload = arguments[0].deliveryTagInPayload;
     if (arguments[0].prefetchCount != undefined)
       options.prefetchCount = arguments[0].prefetchCount;
+    if (arguments[0].exclusive)
+        options.exclusive = arguments[0].exclusive;
 
   }
 
   // basic consume
-  var rawOptions = { noAck: !options.ack };
+  var rawOptions = {
+      noAck: !options.ack,
+      exclusive: options.exclusive
+  };
   if (options.ack) {
     rawOptions['prefetchCount'] = options.prefetchCount;
   }


### PR DESCRIPTION
The ability to request exclusive access to a queue that is not autodeleted is hidden behind the subscribeRaw function. It is a handy thing to have to automatic failover of listening clients. Only one can connect at a time, and if that one dies, another can immediately take over and be assured of exclusivity.
