### PR TITLE
When parsing URI, make sure the vhost starts with a slash.

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -1002,6 +1002,9 @@ function urlOptions(connectionString) {
   }
   if (url.pathname) {
     opts.vhost = unescape(url.pathname.substr(1));
+    if(opts.vhost[0] != '/') {
+        opts.vhost = '/' + opts.vhost;
+    }
   }
   return opts;
 }


### PR DESCRIPTION
At least RabbitMQ expects the vhost to always start with '/'.
