### PR TITLE
Add callback to Connection.publish

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -1399,7 +1399,7 @@ Connection.prototype.exchange = function (name, options, openCallback) {
 // Publishes a message to the default exchange.
 Connection.prototype.publish = function (routingKey, body, options, callback) {
   if (!this._defaultExchange) this._defaultExchange = this.exchange();
-    return this._defaultExchange.publish(routingKey, body, options, callback);
+  return this._defaultExchange.publish(routingKey, body, options, callback);
 };
 
 


### PR DESCRIPTION
A callback has been added to Connection.prototype.publish to pass it through to the exchange.

related with https://github.com/adunkman/node-amqp/commit/485637932f00d7f603c0191099efb5d7c7605505
