### PR TITLE
shift() can reject a message.

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -1742,9 +1742,13 @@ Queue.prototype.subscribe = function (/* options, messageListener */) {
 Queue.prototype.subscribeJSON = Queue.prototype.subscribe;
 
 /* Acknowledges the last message */
-Queue.prototype.shift = function () {
+Queue.prototype.shift = function (reject,requeue) {
   if (this._lastMessage) {
-    this._lastMessage.acknowledge();
+    if(reject) {
+        this._lastMessage.reject(requeue ? true : false);
+    } else {
+        this._lastMessage.acknowledge();
+    }
   }
 };
 


### PR DESCRIPTION
Queue.shift() should be able to reject a message if we want to. We can pass `reject` and `requeue` options if we need to reject the current message.
