### PR TITLE
Accept an Array of URL's, so both host AND port can be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,3 +406,7 @@ This is the reverse of the exchange.bind method above, and will stop messages
 from srcExchange/routingKey from being sent to the destination exchange. 
 
 This method will emit `'exchangeUnbindOk'` when complete.
+
+### Running Tests
+test.js is ancient and no longer updated (hopefully it will be removed at some point in the future).
+To run the tests, install couchdb and have it in admin-party mode running on localhost then run `make test`.

--- a/amqp.js
+++ b/amqp.js
@@ -985,6 +985,8 @@ var defaultOptions = { host: 'localhost'
 var defaultImplOptions = { defaultExchangeName: '', reconnect: true , reconnectBackoffStrategy: 'linear' , reconnectExponentialLimit: 120000, reconnectBackoffTime: 1000 };
 
 function urlOptions(connectionString) {
+  if (Array.isArray(connectionString)) return connectionString;
+
   var opts = {};
   var url = URL.parse(connectionString);
   var scheme = url.protocol.substring(0, url.protocol.lastIndexOf(':'));
@@ -1040,18 +1042,21 @@ Connection.prototype.reconnect = function () {
 Connection.prototype.connect = function () {
   // If you pass a array of hosts, lets choose a random host, or then next one.
   var connectToHost = this.options.host;
+  var connectToPort = this.options.port;
 
-  if(Array.isArray(this.options.host) == true){
-    if(this.hosti == null){
-      this.hosti = Math.random()*this.options.host.length >> 0;
-    }else{
-      this.hosti = (this.hosti+1) % this.options.host.length;
+  if (Array.isArray(this.options.url)) {
+    if(this.urli == null) {
+      this.urli = Math.random() * this.options.url.length >> 0;
+    }else {
+      this.urli = (this.urli + 1) % this.options.url.length;
     }
-    connectToHost = this.options.host[this.hosti]
+    parsedUrl = urlOptions(this.options.url[this.urli]);
+    connectToHost = parsedUrl.host;
+    connectToPort = parsedUrl.port;
   }
 
   // Connect socket
-  net.Socket.prototype.connect.call(this, this.options.port, connectToHost);
+  net.Socket.prototype.connect.call(this, connectToPort, connectToHost);
   // Apparently, it is not possible to determine if an authentication error
   // has occurred, but when the connection closes then we can HINT that a
   // possible authentication error has occured.  Although this may be a bug

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   , { "name" : "James Carr" }
   , { "name" : "David Barshow" }
   , { "name" : "Jason Pincin" }
+  , { "name" : "Ethan Mick" }
   ]
 , "repository" :
   { "type" : "git"

--- a/test/test-connection-array.js
+++ b/test/test-connection-array.js
@@ -9,7 +9,7 @@ if (process.argv[2]) {
   if (server[1]) options.port = parseInt(server[1]);
 }
 
-options.host = [options.host,"nohost"];
+options.url = ['amqp://localhost:5672', 'amqp://localhost:5673'];
 
 var implOpts = {
   defaultExchangeName: 'amq.topic'
@@ -26,8 +26,3 @@ connection = amqp.createConnection(options, implOpts);
 connection.on('ready', function() {
     connection.destroy();
 });
-
-
-
-
-


### PR DESCRIPTION
If testing locally, or if nodes are running on different ports, there is no way to specify to connect to Host A, on Port B. Passing in an array of hosts is good - but it doesn't work if a cluster is running on a single computer (such as for testing, or when two brokers are running on the same computer).

To fix this, I changed what you should pass in as an Array. Rather than passing in the hosts as an Array, pass in the url: as an Array, and the host/port are parsed out of that.

This REMOVES the host Array functionality, I figured since this hadn't been released as 0.1.5 we could change it. But I can add backwards compatibility if necessary.
