### PR TITLE
Add missing properties information for exchange.publish documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,14 @@ is converted to JSON.
 - `headers`: default `{}`. Arbitrary application-specific message headers.
 - `deliveryMode`: Non-persistent (1) or persistent (2)
 - `priority`: The message priority, 0 to 9.
+- `correlationId`: default null. Application correlation identifier
 - `replyTo`: Usually used to name a reply queue for a request message.
+- `expiration`: default null. Message expiration specification
+- `messageId`: default null. Application message identifier
+- `timestamp`: default null. Message timestamp
+- `type`: default null. Message type name
+- `userId`: default null. Creating user id
+- `appId`: default null. Creating application id
 
 `callback` is a function that will get called if the exchange is in confirm mode,
 the value sent will be true or false, this is the presense of a error so true, means

--- a/amqp.js
+++ b/amqp.js
@@ -1250,7 +1250,7 @@ Connection.prototype._sendMethod = function (channel, method, args) {
 // - priority (0-9)
 // - correlationId
 // - replyTo
-// - experation
+// - expiration
 // - messageId
 // - timestamp
 // - userId
@@ -2206,7 +2206,7 @@ Exchange.prototype._onMethod = function (channel, method, args) {
 // - priority (0-9)
 // - correlationId
 // - replyTo
-// - experation
+// - expiration
 // - messageId
 // - timestamp
 // - userId


### PR DESCRIPTION
There are some properties used for exchange.publish but not listed in the doc (like userId, appId. etc..). These are written here: http://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf under 1.8.1. Property and Method Summary, page 42. Node-amqp accept these as key-value for the options object. 

It's already supported by node-amqp but now written in the docs. This commit just add those missing information.
