### PR TITLE
Pass messageCount and consumerCount to queue openCallback

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -1929,7 +1929,7 @@ Queue.prototype._onMethod = function (channel, method, args) {
       this.name = args.queue;
       this.connection.queues[this.name] = this;
       if (this._openCallback) {
-        this._openCallback(this);
+        this._openCallback(this, args.messageCount, args.consumerCount);
         this._openCallback = null;
       }
       // TODO this is legacy interface, remove me


### PR DESCRIPTION
Couldn't see another way to get these values.  There is the "open" event that has the values but it is marked as deprecated. I looked on the queue object but don't see a way to get these values.
