### PR TITLE
Remove preferGlobal

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
 , "description" : "AMQP driver for node"
 , "keywords" : [ "amqp" ]
 , "version" : "0.1.6"
-, "preferGlobal" : true
 , "author" : { "name" : "Ryan Dahl" }
 , "contributors" :
   [ { "name" : "Vasili Sviridov" }


### PR DESCRIPTION
Why was it needed in the first place? I can't see any command line binaries that you'd want installed globally (like with coffee-script).

This also fixes the `npm WARN prefer global amqp@0.1.6 should be installed with -g` warnings from NPM.

If there is a legitimate reason for using `preferGlobal`, please close this PR.
