### PR TITLE
Add option to choose which host in a host array is chosen first

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -1037,12 +1037,16 @@ Connection.prototype.reconnect = function () {
 };
 
 Connection.prototype.connect = function () {
-  // If you pass a array of hosts, lets choose a random host, or then next one.
+  // If you pass a array of hosts, lets choose a random host or the preferred host number, or then next one.
   var connectToHost = this.options.host;
 
   if(Array.isArray(this.options.host) == true){
     if(this.hosti == null){
-      this.hosti = Math.random()*this.options.host.length >> 0;
+      if(this.options.hostPreference !== undefined && typeof this.options.hostPreference == 'number') {
+        this.hosti = (this.options.hostPreference<this.options.host.length)?this.options.hostPreference:this.options.host.length-1; 
+      }else{   
+        this.hosti = Math.random()*this.options.host.length >> 0;
+      }
     }else{
       this.hosti = (this.hosti+1) % this.options.host.length;
     }

--- a/test/test-connection-array-preference.js
+++ b/test/test-connection-array-preference.js
@@ -1,0 +1,40 @@
+testLog = function(name, message) { console.log("Test case: "+name+":", message); };
+assert =  require('assert');
+amqp = require('../amqp');
+
+var options = global.options || {};
+if (process.argv[2]) {
+  var server = process.argv[2].split(':');
+  if (server[0]) options.host = server[0];
+  if (server[1]) options.port = parseInt(server[1]);
+}
+
+
+options.host = [options.host,"nohost"];
+
+var implOpts = {
+  defaultExchangeName: 'amq.topic'
+};
+
+//If we specify a number bigger than the array, amqp.js will just use the last element in the array
+for (var i = 0; i < 3; i++){
+  (function(i){
+    var connection;
+    var connectionOptions = options;
+    connectionOptions.hostPreference = i;
+  
+    console.log("Connecting to host " + i + " " + options.host[i]);
+    connection = amqp.createConnection(connectionOptions, implOpts);
+  
+    connection.on('ready', function() {
+        connection.destroy();
+    });
+
+  })(i);
+
+}
+
+
+
+
+


### PR DESCRIPTION
This patch allows a user to set a hostPreference option which correlates to the element in the host array. Used for example if you have primary and secondary servers.

Example usage:

``` Javascript
var options = {
host: [host1, host2]
};
options.hostPreference = 0; //Use host1 as first choice
options.hostPreference = 1; //Use host2 as first choice
options.hostPreference = 2; //Use the last host in the array (host2) as first choice
```

If the preferred host is not available, the reconnect function will work as normal and move to the next host in the array.

Test case is in test/test-connection-array-preference.js - Note that it will attempt to connect to nohost twice, then fail over to the actual host you supply

```
node test/test-connection-array-preference.js youramqpip:youramqpport
```
