### PR TITLE
fix bug of parsing and serializing the longlong domain.

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -402,7 +402,11 @@ function parseFields (buffer, fields) {
 
       case 'timestamp':
       case 'longlong':
-        value = parseInt(buffer, 8);
+        //value = parseInt(buffer, 8);
+        value = new Buffer(8);
+        for (var j = 0; j < 8; j++) {
+            value[j] = buffer[buffer.read++];
+        }
         break;
 
       case 'shortstr':
@@ -761,7 +765,10 @@ function serializeFields (buffer, fields, args, strict) {
 
       case 'timestamp':
       case 'longlong':
-        serializeInt(buffer, 8, param);
+        //serializeInt(buffer, 8, param);
+        for (var j = 0; j < 8; j++) {
+            buffer[buffer.used++] = param[j];
+        }
         break;
 
       case 'shortstr':


### PR DESCRIPTION
In rabbitmq, the domain with longlong type is 64-bit integer. 
But if the delivery-tag reachs 64-bit integer, the parseFields and 
serializeFields functions can not work well. So I fix this two functions
to support 64-bit integer.
