### PR TITLE
Fix prefetchCount of 0 to call basicQos

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -1601,7 +1601,7 @@ Queue.prototype.subscribeRaw = function (/* options, messageListener */) {
   options['state'] = 'opening';
   this.consumerTagOptions[consumerTag] = options;
 
-  if (options.prefetchCount) {
+  if (options.prefetchCount != undefined) {
     self.connection._sendMethod(self.channel, methods.basicQos,
         { reserved1: 0
         , prefetchSize: 0

--- a/test/test-queue-subscribe-event.js
+++ b/test/test-queue-subscribe-event.js
@@ -1,0 +1,25 @@
+require('./harness');
+
+var basic_qos_emitted = false;
+
+// make sure the 'basicQosOk' event is emitted properly with prefetchCount: 0
+connection.on('ready', function() {
+  var e = connection.exchange('node-subscribe-event', {type: 'fanout'});
+  connection.queue('node-subscribe-event-queue', function(q) {
+    q.bind(e, '');
+    q.subscribe({ ack: true, prefetchCount: 0 }, function() {
+      connection.end();
+    });
+
+    q.on('basicQosOk', function() {
+      basic_qos_emitted = true;
+    });
+
+    e.publish('node-subscribe-event-queue', { foo: 'bar' });
+  });
+});
+
+
+process.on('exit', function() {
+  assert( basic_qos_emitted );
+});


### PR DESCRIPTION
When subscribing to a queue, prefetchCount of 0 should still call basicQos
and end up emitting the "basicQosOk" event.
