### PR TITLE
Pass error events up when reconnect is false

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -805,7 +805,7 @@ function Connection (connectionArgs, options, readyCallback) {
   var backoffTime = null;
   this.connectionAttemptScheduled = false;
 
-  var backoff = function () {
+  var backoff = function (e) {
     if (self._inboundHeartbeatTimer !== null) {
       clearTimeout(self._inboundHeartbeatTimer);
       self._inboundHeartbeatTimer = null;
@@ -873,6 +873,9 @@ function Connection (connectionArgs, options, readyCallback) {
           self.connectionAttemptScheduled = false;
           self.reconnect();
         }, backoffTime);
+      } else {
+        self.removeListener('error', backoff);
+        self.emit('error', e);
       }
     }
   };
@@ -935,9 +938,7 @@ function Connection (connectionArgs, options, readyCallback) {
     self._inboundHeartbeatTimerReset();
   });
 
-  self.addListener('error', function () {
-    backoff();
-  });
+  self.addListener('error', backoff);
 
   self.addListener('ready', function () {
     // Reset the backoff time since we have successfully connected.


### PR DESCRIPTION
When reconnect isn't enabled (i.e. you pass reconnect: false), error events get silently swallowed in the backoff() function.
Instead, backoff should do what it does now but re-emit the error if reconnect is false.
