### PR TITLE
Bump node dependency requirements to node 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   { "url" : "http://github.com/postwait/node-amqp/issues"
   }
 , "main" : "./amqp"
-, "engines" : { "node" : "0.4 || 0.5 || 0.6 || 0.8" }
+, "engines" : { "node" : "0.4 || 0.5 || 0.6 || 0.8 || 0.9 || 0.10" }
 , "licenses" :
   [ { "type" : "MIT"
     , "url" : "http://github.com/postwait/node-amqp/raw/master/LICENSE-MIT"


### PR DESCRIPTION
Version deps cause warnings when npm installing on top of node 0.10.
