### PR TITLE
Fix for adding event listeners on every reconnect.

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -1060,11 +1060,15 @@ Connection.prototype.connect = function () {
       message: 'Connection ended: possibly due to an authentication failure.'
     });
   }
-  // add this handler with #on not #once (so it can be removed by #removeListener)
-  this.on('end', possibleAuthErrorHandler);
-  this.once('ready', function () {
-    this.removeListener('end', possibleAuthErrorHandler);
-  });
+  // ensure we only add this handler once, and not once per reconnect
+  if (!this._hasPossibleAuthErrorHandler) {
+    // add this handler with #on not #once (so it can be removed by #removeListener)
+    this.on('end', possibleAuthErrorHandler);
+    this.on('ready', function () {
+      this.removeListener('end', possibleAuthErrorHandler);
+    });
+    this._hasPossibleAuthErrorHandler = true;
+  }
 };
 
 Connection.prototype._onMethod = function (channel, method, args) {


### PR DESCRIPTION
The current reconnect logic adds listeners for the `possibleAuthErrorHandler` on every reconnect. This eventually makes event emitter scream about listener leak.

The problem shows like this after about 11 reconnects.

```
warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at Connection.EventEmitter.addListener (events.js:160:15)
    at Connection.connect (/Users/martin/dev/scanpix/locko/node_modules/amqp/amqp.js:1070:10)
    at Connection.reconnect (/Users/martin/dev/scanpix/locko/node_modules/amqp/amqp.js:1038:8)
    at null._onTimeout (/Users/martin/dev/scanpix/locko/node_modules/amqp/amqp.js:876:16)
    at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
```
