### PR TITLE
Address bug in which delivery tag returns as buffer, preventing lookups from _unAcked table.

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -2156,6 +2156,7 @@ Exchange.prototype._onMethod = function (channel, method, args) {
 
     case methods.basicAck:
       this.emit('basic-ack', args);
+      var sequenceNumber = args.deliveryTag.readUInt32BE(4);
 
       if(args.deliveryTag == 0 && args.multiple == true){
         // we must ack everything
@@ -2171,10 +2172,10 @@ Exchange.prototype._onMethod = function (channel, method, args) {
             delete this._unAcked[tag]
           }
         }
-      }else if(this._unAcked[args.deliveryTag] && args.multiple == false){
+      }else if(this._unAcked[sequenceNumber] && args.multiple == false){
         // simple single ack
-        this._unAcked[args.deliveryTag].emitAck()
-        delete this._unAcked[args.deliveryTag]
+        this._unAcked[sequenceNumber].emitAck()
+        delete this._unAcked[sequenceNumber]
       }
       
       break;


### PR DESCRIPTION
We were unable to get `publish` methods to return callbacks. Examination
of the code revealed that the `deliveryTag` is returned as a buffer,
while the `_unAcked` table is keyed by a string representing
`_sequence`. This caused `_unAcked` callbacks to be unretrievable when
the publication event was acknowledged.

The "fix" in this code at least identifies the error. The approach is to
read the last 4 bytes of the buffer. Note that the buffer is 8 bytes,
meaning we are ignoring the first 4 bytes. However, this is seeded with
the `_sequence` value (an integer) at send time, and therefore will
never be larger than 4 bytes anyway.
