### PR TITLE
Since deliveryTag became a buffer publish acknowledgements from exchanges...

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -2249,26 +2249,26 @@ Exchange.prototype._onMethod = function (channel, method, args) {
       this.emit('basic-ack', args);
       var sequenceNumber = args.deliveryTag.readUInt32BE(4);
 
-      if(args.deliveryTag == 0 && args.multiple == true){
+      if (sequenceNumber == 0 && args.multiple == true) {
         // we must ack everything
-        for(var tag in this._unAcked){
+        for (var tag in this._unAcked) {
           this._unAcked[tag].emitAck()
           delete this._unAcked[tag]
         }
-      }else if(args.deliveryTag != 0 && args.multiple == true){
+      } else if (sequenceNumber != 0 && args.multiple == true) {
         // we must ack everything before the delivery tag
-        for(var tag in this._unAcked){
-          if(tag <= args.deliveryTag){
+        for (var tag in this._unAcked) {
+          if (tag <= sequenceNumber) {
             this._unAcked[tag].emitAck()
             delete this._unAcked[tag]
           }
         }
-      }else if(this._unAcked[sequenceNumber] && args.multiple == false){
+      } else if (this._unAcked[sequenceNumber] && args.multiple == false) {
         // simple single ack
         this._unAcked[sequenceNumber].emitAck()
         delete this._unAcked[sequenceNumber]
       }
-      
+
       break;
 
     case methods.basicReturn:


### PR DESCRIPTION
... opened with confirm=true were not being recognised.  Pull request #206, which has been accepted, only addressed 1 of the 3 scenarios required.  This commit addresses the other 2 scenarios which were originally still trying to compare an integer with a buffer.
