### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ random name.
 
 ### connection.queue(name, options, openCallback)
 
-Returns a reference to a queue. The options are
+Returns a reference to a queue. The name parameter is required, unlike pika which defaults the name to `''`. The options are
 
 - `passive`: boolean, default false.
     If set, the server will not create the queue.  The client can use


### PR DESCRIPTION
Add a note that states that `node-amqp` differs from pika in that one cannot omit the name parameter from the queue creator.
