### PR TITLE
fix reconnect after channel closed by server

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -2110,7 +2110,7 @@ Queue.prototype._onMethod = function (channel, method, args) {
     case methods.channelClose:
       this.state = "closed";
       this.closeOK();
-      this.connection.queueClosed(this.name);
+      // this.connection.queueClosed(this.name);
       var e = new Error(args.replyText);
       e.code = args.replyCode;
       this.emit('error', e);


### PR DESCRIPTION
If client send some illegal data (send same ack data twice for example) on a channel, server will close this channel and the connection. And if we need reconnect after connection closed, the original code will miss subscribe to the queue.