### PR TITLE
Fix channel overflow

### DIFF
--- a/amqp.js
+++ b/amqp.js
@@ -1501,13 +1501,17 @@ Connection.prototype._bodyToBuffer = function (body) {
 Connection.prototype.generateChannelID = function () {
   var attemptCount = 0,
       minChannelID = 1, // avoid channel 0
+      maxChannelID = this.channelMax,
       channelID;
 
   while (attemptCount < this.channelMax) {
     attemptCount += 1;
 
-    // actual new channel ID follows the last known one, avoiding channel 0
-    channelID = minChannelID + (this.lastUsedChannelID - minChannelID + attemptCount) % (this.channelMax - minChannelID);
+    // new suggested channel ID follows the last known one
+    channelID = this.lastUsedChannelID + attemptCount;
+
+    // keep suggested channel ID in bounds
+    channelID = minChannelID + (channelID - minChannelID) % (maxChannelID - minChannelID);
 
     // try again if already taken
     if (this.channels[channelID]) {


### PR DESCRIPTION
https://github.com/postwait/node-amqp/issues/205

The client library is ignoring the max channel ID limit sent by the server (65535) instead of properly wrapping the ID back around to 1. When the client-generated channel ID hits the limit, the server kicks out the client with an error.

Changed to wrap-around the channel ID properly, while avoiding already-used IDs.
