### PR TITLE
Fix for issue #246: Connection does not close cleanly

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -65,6 +65,7 @@ var Connection = module.exports = function Connection (connectionArgs, options, 
   }
   
   this.connectionAttemptScheduled = false;
+  this.connectionClosing = false;
   this._defaultExchange = null;
   this.channelCounter = 0;
   this._sendBuffer = new Buffer(maxFrameBuffer);
@@ -339,14 +340,21 @@ Connection.prototype.publish = function (routingKey, body, options, callback) {
 
 Connection.prototype.end = function() {
   if (this.socket) {
-    // According to AMQP spec, send connectionClose to server.
-    // Socket will be closed when server responds connectionCloseOk.
-    this._sendMethod(0, methods.connectionClose, {
-      replyCode: 200,
-      replyText: 'ok',
-      classId: 0,
-      methodId: 0
-    });
+    if (this.state === 'closed') {
+      // Connection is already closed, just close socket to be sure...
+      this.socket.end();
+    } else {
+      // According to AMQP spec, send connectionClose to server.
+      // Socket will be closed when server responds connectionCloseOk.
+      // http://www.rabbitmq.com/amqp-0-9-1-reference.html#connection.close
+      this._sendMethod(0, methods.connectionClose, {
+        replyCode: 200,
+        replyText: 'OK',
+        classId: 0,
+        methodId: 0
+      });
+      this.connectionClosing = true;
+    }
   }
 }
 
@@ -402,6 +410,13 @@ Connection.prototype._outboundHeartbeatTimerReset = function () {
 
 Connection.prototype._onMethod = function (channel, method, args) {
   debug(channel + " > " + method.name + " " + JSON.stringify(args));
+
+  // If closing, any methods except close and close-ok must be discarded.
+  // See: http://www.rabbitmq.com/amqp-0-9-1-reference.html#connection.close
+  if (this.connectionClosing && method != methods.connectionClose && method != methods.connectionCloseOk) {
+    debug("Discarding message since 'close' message has already been sent.");
+    return;
+  }
 
   // Channel 0 is the control channel. If not zero then delegate to
   // one of the channel objects.
@@ -484,11 +499,13 @@ Connection.prototype._onMethod = function (channel, method, args) {
         console.log('Unhandled connection error: ' + args.replyText);
       }
       this.socket.destroy(e);
+      this.connectionClosing = false;
       break;
 
     case methods.connectionCloseOk:
       if (this.socket) {
         this.socket.end();
+        this.connectionClosing = false;
       }
       break;
 

--- a/test/test-connection-end.js
+++ b/test/test-connection-end.js
@@ -1,5 +1,4 @@
 require('./harness').run();
-var assert = require('assert');
 var cbcnt = 0;
 
 // Only way to test if we disconnect cleanly is to look for
@@ -14,12 +13,13 @@ connection._onMethod = function (channel, method, args) {
 
 // And verify that we do really call end on the socket.
 connection.on('end', function() {
-	cbcnt++;
+  cbcnt++;
 });
 
 connection.on('ready', function(){
-    connection.end();
+  connection.end();
 });
+
 process.addListener('exit', function () {
   assert.equal(cbcnt, 2);
 });


### PR DESCRIPTION
Without this modification, calls to connection.end will close the socket without notifying the RabbitMQ server.  This results in a warning in the RabbitMQ logs stating that the connection was closed abruptly.

This fix follows the AMQP 0-9-1 specification by sending the connectionClose method to the server and waiting for a connectionCloseOk response before closing the connection.
