### PR TITLE
Remove lodash defaults

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -15,7 +15,7 @@ var Exchange = module.exports = function Exchange (connection, channel, name, op
   this.binds = 0; // keep track of queues bound
   this.exchangeBinds = 0; // keep track of exchanges bound
   this.sourceExchanges = {};
-  this.options = _.defaults(options || {}, {autoDelete: true});
+  this.options = options || { autoDelete: true};
   this._openCallback = openCallback;
 
   this._sequence = null;


### PR DESCRIPTION
I found there is an error where exchange is not calling back after updated to postwait/node-amqp@7c245205646330427b43415556eec4b7697df74e

Therefore I revert line 18 to previous version. 
