### PR TITLE
Adds support for detecting when the write socket is full and cannot safely buffer more data

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -559,7 +559,7 @@ Connection.prototype._createSocket = function() {
   var methods = ['end', 'destroy', 'write', 'pause', 'resume', 'setEncoding', 'ref', 'unref', 'address'];
   _.each(methods, function(method){
     self[method] = function(){
-      self.socket[method].apply(self.socket, arguments);
+      return self.socket[method].apply(self.socket, arguments);
     };
   });
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -261,6 +261,11 @@ Connection.prototype.addAllListeners = function() {
     self._outboundHeartbeatTimerReset();
   });
 
+  // Our Writable stream has room for more data.
+  self.addListener('drain', function () {
+    self.isBackedUp = false; 
+  });
+
   // Apparently, it is not possible to determine if an authentication error
   // has occurred, but when the connection closes then we can HINT that a
   // possible authentication error has occured.  Although this may be a bug
@@ -614,7 +619,16 @@ Connection.prototype._sendBody = function (channel, body, properties) {
     buffer.copy(b, b.used, pos, pos+sz);
     b.used += sz;
     b[b.used++] = 206; // constants.frameEnd;
-    this.write(b);
+    
+    if (!this.write(b)) {
+      // socket.write() returned false, which means it can't accept any more
+      // data. Writing more data while isBackedUp == true will lead to heap
+      // growth, since the additional data will be buffered in memory.
+      // We should wait for a 'drain' event which will signal that it's safe
+      // to start writing data again and will automatically toggle isBackedUp
+      // to false.
+      this.isBackedUp = true;
+    }
 
     len -= sz;
     pos += sz;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -540,7 +540,8 @@ Connection.prototype._createSocket = function() {
 
   var options = {
     port: this.options.port,
-    host: hostName
+    host: hostName,
+    highWaterMark: this.options.writeBufferSize
   };
 
   // Connect socket


### PR DESCRIPTION
This implements a potential mechanism for preventing a serious memory overflow issue in the way `Connection` sends data to the amqp server. The problem in the current implementation is that if data is written (published) to the underlying socket faster than the socket can push it out to the amqp server, the additional data gets buffered into memory. This buffer can grow indefinitely. (See #57)

This patch exposes the underlying socket's buffer status, so that a decision can be made upstream on whether to keep pushing data despite the overflow.

When the socket is full, the `Connection`'s `isBackedUp` property is set to `true`. When this happens, the client should stop sending data or start buffering it in some safe way. For example:

```
if (queue.connection.isBackedUp) {
  // can't safely send message without growing memory queue
} else {
  conn.publish("some-queue", message);
}
```

`isBackedUp` is automatically set to `false` when the socket becomes safely writable again.

Additionally, a `writeBufferSize` option (number of bytes) can be provided to the `Connection` constructor to set the `highWaterMark` for the underlying socket. This should effectively set the maximum buffer size.