### PR TITLE
Change channels ids to be compared as strings not numbers

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -191,7 +191,7 @@ Connection.prototype.addAllListeners = function() {
       // channels that they are no longer connected so that nobody attempts
       // to send messages which would be doomed to fail.
       for (var channel in self.channels) {
-        if (channel !== 0) {
+        if (channel !== '0') {
           self.channels[channel].state = 'closed';
         }
       }
@@ -249,8 +249,7 @@ Connection.prototype.addAllListeners = function() {
     if (self.implOptions.reconnect) {
       // Reconnect any channels which were open.
       _.each(self.channels, function(channel, index) {
-        // FIXME why is the index "0" instead of 0?
-        if (index !== "0") channel.reconnect();
+        if (index !== '0') channel.reconnect();
       });
     }
 


### PR DESCRIPTION
 Change channels ids to be compared as strings since they are stored in an object (`self.channels`). Not sure if it could possibly fix any known issues related to the "control channel" incorrectly falling into a state of "closed".
