### PR TITLE
Reduce Buffer creation and copy on message send

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -68,6 +68,11 @@ var Connection = module.exports = function Connection (connectionArgs, options, 
   this._defaultExchange = null;
   this.channelCounter = 0;
   this._sendBuffer = new Buffer(maxFrameBuffer);
+
+  this._fbBuffer = new Buffer(7);
+  this._fbBuffer[this._fbBuffer.used++] = 3; // constants.frameBody
+  this._eofBuffer = new Buffer(1);
+  this._eofBuffer[this._eofBuffer.used++] = 206; // constants.frameEnd
 };
 util.inherits(Connection, EventEmitter);
 
@@ -602,19 +607,21 @@ Connection.prototype._sendBody = function (channel, body, properties) {
 
   this._sendHeader(channel, buffer.length, properties);
 
+  this._fbBuffer.used = 1;
+  serializer.serializeInt(this._fbBuffer, 2, channel);
+
   var pos = 0, len = buffer.length;
   while (len > 0) {
     var sz = len < maxFrameBuffer ? len : maxFrameBuffer;
 
-    var b = new Buffer(7 + sz + 1);
-    b.used = 0;
-    b[b.used++] = 3; // constants.frameBody
-    serializer.serializeInt(b, 2, channel);
-    serializer.serializeInt(b, 4, sz);
-    buffer.copy(b, b.used, pos, pos+sz);
-    b.used += sz;
-    b[b.used++] = 206; // constants.frameEnd;
-    this.write(b);
+    this._fbBuffer.used = 3;
+    serializer.serializeInt(this._fbBuffer, 4, sz);
+
+    var slice = buffer.slice(pos, pos+sz);
+
+    this.write(this._fbBuffer);
+    this.write(slice);
+    this.write(this._eofBuffer);
 
     len -= sz;
     pos += sz;


### PR DESCRIPTION
Rather than allocate new buffers for every frame, reuse buffers for
frame start and frame end. Directly pass the caller's buffer to socket
write instead of copying it first.

In my testing, this results in a 33% speedup for message sends.
