### PR TITLE
Do not allow channel id values above 2^16

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -291,8 +291,12 @@ Connection.prototype.exchange = function (name, options, openCallback) {
   if (!options) options = {};
   if (name !== '' && options.type === undefined) options.type = 'topic';
 
-  this.channelCounter++;
-  var channel = this.channelCounter;
+  try{
+    var channel = this.generateChannelId();
+  }catch(exception){
+    this.emit("error", exception);
+    return;
+  }
   var exchange = new Exchange(this, channel, name, options, openCallback);
   this.channels[channel] = exchange;
   this.exchanges[name] = exchange;
@@ -318,8 +322,12 @@ Connection.prototype.queue = function (name /* options, openCallback */) {
     callback = arguments[1];
   }
 
-  this.channelCounter++;
-  var channel = this.channelCounter;
+  try{
+    var channel = this.generateChannelId();
+  }catch(exception){
+    this.emit("error", exception);
+    return;
+  }
 
   var q = new Queue(this, channel, name, options, callback);
   this.channels[channel] = q;
@@ -731,4 +739,23 @@ Connection.prototype._sendMethod = function (channel, method, args) {
   this.write(c);
   
   this._outboundHeartbeatTimerReset();
+};
+
+// tries to find the next available id slot for a channel
+Connection.prototype.generateChannelId = function () {
+  // start from the last used slot id
+  var channelId = this.channelCounter;
+  while(true){
+    // use values in range of 1..65535
+    channelId = channelId % 65535 + 1;
+    if(!this.channels[channelId]){
+      break;
+    }
+    // after a full loop throw an Error
+    if(channelId == this.channelCounter){
+      throw new Error("No valid Channel Id values available");
+    }
+  }
+  this.channelCounter = channelId;
+  return this.channelCounter;
 };

--- a/test/test-channel-overflow.js
+++ b/test/test-channel-overflow.js
@@ -1,0 +1,28 @@
+require('./harness').run();
+
+var channelMax = 65536; // 2^16
+
+connection.addListener('ready', function () {
+  puts("connected to " + connection.serverProperties.product);
+  
+  // preset channel counter value near max limit
+  connection.channelCounter = channelMax - 1;
+
+  // opening a channel with channel counter up to channelMax is ok
+  connection.exchange('amq.topic', {type: 'topic'}, function(exchange) {
+    assert(connection.channelCounter, channelMax);
+
+    // if the client tries to open a channel with counter value above channelMax, the request fails
+    connection.exchange('amq.topic', {type: 'topic'}, function(exchange) {
+
+      // if channel counter is above channelMax, this line should never be reached
+      assert(connection.channelCounter != channelMax + 1);
+      connection.end();
+    });
+  });
+});
+
+connection.addListener('error', function () {
+  assert(0);
+  connection.end();
+});


### PR DESCRIPTION
This is another implementation of https://github.com/postwait/node-amqp/pull/237 to keep channel id values below 65536 which is the largest number RabbitMQ accepts. #237 is a bit more complex and probably a better solution but it is out of sync with the current codebase and it does not include a test to prove the issue.

This pull request adds logic to loop and reuse channel id values in the range of 1..65536.
