### PR TITLE
Implement #229: Support for Consumer Cancel Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,14 @@ You can also specify additional client properties for your connection
 by setting the `clientProperties` field on the `options` object.
 
     { clientProperties: { applicationName: 'myApplication'
+                        , capabilities: { consumer_cancel_notify: true
+                                        }
                         }
     }
+
+If the `consumer_cancel_notify` capability is set to `true` (as above), then
+RabbitMQ's [Consumer Cancel Notification](http://www.rabbitmq.com/consumer-cancel.html)
+feature will be enabled.
 
 By default the following client properties are set
 
@@ -298,6 +304,12 @@ option passed when creating in a queue in that the queue itself is not exclusive
 only the consumers. This means that long lived durable queues can be used
 as exclusive queues.
 
+If the `consumer_cancel_notify` capability was enabled when the connection was
+created, the queue will emit `basicCancel` upon receiving a consumer cancel
+notification from the server.  The queue's channel will be automatically closed.
+In a clustered environment, developers may want to consider automatically
+re-subscribing to the queue on this event.
+
 This method will emit `'basicQosOk'` when ready.
 
 
@@ -379,6 +391,9 @@ the queue will only be deleted if there are no consumers. If
 +options.ifEmpty+ is true, the queue will only be deleted if it has no
 messages.
 
+Note: the successful destruction of a queue will cause a consumer cancel 
+notification to be emitted (for clients who have enabled the 
+`consumer_cancel_notify` option when creating the connection).
 
 
 

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -86,10 +86,10 @@ Channel.prototype._onChannelMethod = function(channel, method, args) {
   }
 };
 
-Channel.prototype.close = function() {
+Channel.prototype.close = function(reason) {
   this.state = 'closing';
   this.connection._sendMethod(this.channel, methods.channelClose,
-                              {'replyText': 'Goodbye from node',
+                              {'replyText': reason ? reason : 'Goodbye from node',
                                'replyCode': 200,
                                'classId': 0,
                                'methodId': 0});

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -462,6 +462,10 @@ Queue.prototype._onMethod = function (channel, method, args) {
     case methods.queueDeleteOk:
       break;
 
+    case methods.basicCancel:
+      this.close("Closed due to basicCancel received on consumer (" + args.consumerTag + ")");
+      break;
+
     default:
       throw new Error("Uncaught method '" + method.name + "' with args " +
           JSON.stringify(args) + "; tasks = " + JSON.stringify(this._tasks));

--- a/test/test-consumer-cancel-notify.js
+++ b/test/test-consumer-cancel-notify.js
@@ -1,0 +1,48 @@
+var harness = require('./harness');
+
+if (typeof(options.clientProperties) === 'undefined') {
+  options.clientProperties = {};
+}
+if (typeof(options.clientProperties.capabilities) === 'undefined') {
+  options.clientProperties.capabilities = {};
+}
+options.clientProperties.capabilities.consumer_cancel_notify = true;
+
+var connection = harness.run();
+var notifyCount = 0;
+
+connection.once('ready', function() {
+  // set a timer to close things if we're not done in one second
+  var finisherId = setTimeout(function () {
+    connection.end();
+  }, 1000);
+
+  connection.queue('node-ccn-queue', function(q) {
+    q.bind("#")
+    q.on('queueBindOk', function() {
+      q.on('basicCancel', function(args) {
+        notifyCount++;
+      });
+
+      q.on('close', function() {
+          connection.end();
+          clearTimeout(finisherId);
+      });
+
+      q.on('basicConsumeOk', function () {
+        connection.queue('node-ccn-queue', function(q2) {
+          q2.destroy();
+        });
+      });
+
+      q.subscribe(function (m) {
+        // no-op
+      })
+    });
+  });
+});
+
+
+process.addListener('exit', function () {
+  assert.equal(1, notifyCount);
+});


### PR DESCRIPTION
This pull request implements support for RabbitMQ's [Consumer Cancel Notifications](http://www.rabbitmq.com/consumer-cancel.html).  

By default, node-amqp will work as it always did-- _without_ consumer cancel notifications.  If developers want to use consumer cancel notifications, they must enable them in the client properties of the connection options.  This is covered in the updates to the README.

When consumer cancel notifications are enabled, the behavior of node-amqp changes in two ways:
1. If a queue is deleted on the server or a slave queue is promoted to master, the queue object in node-amqp will emit `basicCancel`.
2. In the same case mentioned above, the queue object in amqp will also be automatically closed.

Developers can listen for the `basicCancel` event on the queue and take the appropriate action (logging a message, redeclaring, resubscribing, etc).

A new test has been created and all existing tests are passing.  Please consider merging this request.
