### PR TITLE
Don't reference send buffer for socket writes

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -699,7 +699,8 @@ Connection.prototype._sendHeader = function(channel, size, properties) {
 
   b[b.used++] = 206; // constants.frameEnd;
 
-  var s = b.slice(0, b.used);
+  var s = new Buffer(b.used);
+  b.copy(s);
 
   //debug && debug('header sent: ' + JSON.stringify(s));
 
@@ -736,12 +737,13 @@ Connection.prototype._sendMethod = function (channel, method, args) {
 
   b[b.used++] = 206; // constants.frameEnd;
 
-  var c = b.slice(0, b.used);
+  var c = new Buffer(b.used);
+  b.copy(c);
 
-  debug && debug("sending frame: " + c);
+  debug && debug("sending frame: " + c.toJSON());
 
   this.write(c);
-  
+
   this._outboundHeartbeatTimerReset();
 };
 


### PR DESCRIPTION
Fixes #292.

Difficult to reproduce via a test case, but I have deployed this patch to our infrastructure and so far it has eliminated all frame_error issues we were seeing under high message volume.
#292 is potentially a serious protocol corruption issue which may mean that method + header frames can be overwritten across distinct operations under high load or network backpressure conditions.
