### PR TITLE
Trigger a real Error when hinting at auth failure

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -268,9 +268,9 @@ Connection.prototype.addAllListeners = function() {
   // failing silently.
   self.addListener('end', function (){
     if (!this.readyEmitted){
-      this.emit('error', {
-        message: 'Connection ended: possibly due to an authentication failure.'
-      });
+      this.emit('error', new Error(
+        'Connection ended: possibly due to an authentication failure.'
+      ));
     }
   });
 };


### PR DESCRIPTION
As introduced in dc2112939968634c76b9877a6c8e0ba448c0c5cf, the object returned contains no stack information and cannot be used in  `throw`.

Switching it to a real `Error` instance is backwards compatible, but provides more information.
