### PR TITLE
Cleanly disconnect from the server with disconnect()

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ implements the 0.9.1 version of the AMQP protocol.
 - [Connection](#connection)
   - [Connection options and URL](#connection-options-and-url)
   - [connection.publish(queueName, body, options, callback)](#connectionpublishqueuename-body-options-callback)
-  - [connection.end()](#connectionend)
+  - [connection.disconnect()](#connectiondisconnect)
 - [Queue](#queue)
   - [connection.queue(name, options, openCallback)](#connectionqueuename-options-opencallback)
   - [queue.subscribe([options,] listener)](#queuesubscribeoptions-listener)
@@ -208,11 +208,10 @@ named.
 This method proxies to the default exchange's `publish` method and parameters are passed
 through untouched.
 
-### connection.end()
+### connection.disconnect()
 
-`amqp.Connection` is derived from `net.Stream` and has all the same methods.
-So use `connection.end()` to terminate a connection gracefully.
-
+Cleanly disconnect from the server, the socket will not be closed until the
+server responds to the disconnection request.
 
 
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -103,6 +103,16 @@ Connection.prototype.reconnect = function () {
   this.connect();
 };
 
+Connection.prototype.disconnect = function () {
+  debug && debug("Sending disconnect request to server");
+  this._sendMethod(0, methods.connectionClose, {
+    'replyText': 'client disconnect',
+    'replyCode': 200,
+    'classId': 0,
+    'methodId': 0
+  });
+};
+
 Connection.prototype.addAllListeners = function() {
   var self = this;
   var connectEvent = this.options.ssl.enabled ? 'secureConnect' : 'connect';
@@ -479,6 +489,11 @@ Connection.prototype._onMethod = function (channel, method, args) {
         console.log('Unhandled connection error: ' + args.replyText);
       }
       this.socket.destroy(e);
+      break;
+
+    case methods.connectionCloseOk:
+      debug && debug("Received close-ok from server, closing socket");
+      this.socket.end();
       break;
 
     default:


### PR DESCRIPTION
Sends connection.close, and waits for a connection.close-ok before
closing the socket.

connection.end() will still work for backwards compatibility by closing
the underlying socket, but is removed from the documentation.

I'm unsure whether I should have done more work around making sure to blackhole any messages received after sending the connection.close to properly follow the spec[1], or to shut down the object state of the channels and things.

As this is only new behaviour it should be perfectly safe to add regardless.

[1] https://www.rabbitmq.com/amqp-0-9-1-reference.html#connection.close
