### PR TITLE
this.socket.end() needs guard against undefined this.socket

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -99,7 +99,7 @@ Connection.prototype.reconnect = function () {
   }
   debug && debug("Connection lost, reconnecting...");
   // Terminate socket activity
-  this.socket.end();
+  if (this.socket) this.socket.end();
   this.connect();
 };
 


### PR DESCRIPTION
When calling reconnect() the first time, this.socket is not defined. The code I found that broke on this was using https://github.com/orlandov/node-amqp-plus to handle reconnections and only called the reconnect() to avoid having separate paths for connect() and reconnect().

This behavior seems to have changed in d729b384879b7e4e96a1ba07152d1f8a4d1caeed
