### PR TITLE
fix for error events doubling (reconnect off)

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -248,7 +248,6 @@ Connection.prototype.addAllListeners = function() {
         }, backoffTime);
       } else {
         self.removeListener('error', backoff);
-        self.emit('error', e);
       }
     }
   });


### PR DESCRIPTION
Fix for:
when reconnection is off, lib user receives error event from connection object twice.
