### PR TITLE
Set No Delay

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -546,6 +546,10 @@ Connection.prototype._createSocket = function() {
     host: hostName
   };
 
+  // Disable tcp nagle's algo
+  // Default: true, makes small messages faster
+  var noDelay = this.options.noDelay || true;
+
   // Connect socket
   if (this.options.ssl.enabled) {
     debug && debug('making ssl connection');
@@ -555,6 +559,8 @@ Connection.prototype._createSocket = function() {
     debug && debug('making non-ssl connection');
     this.socket = net.connect(options);
   }
+
+  this.socket.setNoDelay(noDelay);
 
   // Proxy events.
   // Note that if we don't attach a 'data' event, no data will flow.


### PR DESCRIPTION
Disable the Nagle algo on the socket by default, this exponentially improves performance on small messages( < 2k) 
