### PR TITLE
When confirm:true, don't consider exchange open until confirmSelectOk

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -63,15 +63,30 @@ Exchange.prototype._onMethod = function (channel, method, args) {
         if (this.options.confirm) {
           this.connection._sendMethod(channel, methods.confirmSelect,
             { noWait: false });
-        }
-        this.state = 'open';
+          // We should wait for the confirmSelectOk message to come back
+          // before we consider the exchange open and fire the open callback.
+          // the handler for confirmSelectOk initializes this._sequence.
+          // whose values are used to match published messages with their
+	  // confirmations.  If we fired the open callback here, publishes
+          // could happen before that intialization.  If this happens,
+          // the first message gets a null value set as its "sequence" value
+          // but the ack comes back with a 1.  The 1 doesn't match anything
+          // in the array of messages awaiting confirmation, and so the
+          // confirmation doesn't do anything and the callback passed into
+          // the publish method never fires.  I've not full investigated, but
+          // presumably any message publishes that are performed before
+          // confirmSelectOk is received would have their confirmation
+          // behave abnormally.  
+	} else {
+          this.state = 'open';
 
-        if (this._openCallback) {
-         this._openCallback(this);
-         this._openCallback = null;
-        }
+          if (this._openCallback) {
+           this._openCallback(this);
+           this._openCallback = null;
+          }
 
-        this.emit('open');
+          this.emit('open');
+        }
       } else {
         this.connection._sendMethod(channel, methods.exchangeDeclare,
             { reserved1:  0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name" : "amqp"
 , "description" : "AMQP driver for node"
 , "keywords" : [ "amqp" ]
-, "version" : "0.2.1"
+, "version" : "0.2.2"
 , "author" : { "name" : "Ryan Dahl" }
 , "contributors" :
   [ { "name" : "Vasili Sviridov" }


### PR DESCRIPTION
If we don't do this the open callback for the exchange may fire prior to this._sequence gets initialized, so 
the code that handles confirmation acks won't match the values saved on messages awaiting
confirmation and the confirmation callback never fires.

I'd have contributed tests, but I can't get the test suite to pass on my machine in a clean clone of postwait/master.  Regardless, I thought I'd submit anyway.  Without this change, the callback passed into exchange.publish never fires, and with it things work as expected within my application.