### PR TITLE
Unset _lastMessage after shift

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -202,6 +202,7 @@ Queue.prototype.shift = function (reject, requeue) {
     } else {
       this._lastMessage.acknowledge();
     }
+    this._lastMessage = null;
   }
 };
 


### PR DESCRIPTION
Repeated ack of the same message cause PRECONDITION_FAILED channel error.