### PR TITLE
Support for connection.blocked

### DIFF
--- a/lib/amqp-definitions-0-9-1.js
+++ b/lib/amqp-definitions-0-9-1.js
@@ -143,6 +143,17 @@ exports.classes = [{
     "name": "closeOk",
     "index": 51,
     "fields": []
+  }, {
+    "name": "blocked",
+    "index": 60,
+    "fields": [{
+      "name": "reason",
+      "domain": "shortstr"
+    }]
+  }, {
+    "name": "unblocked",
+    "index": 61,
+    "fields": []
   }]
 }, {
   "name": "channel",

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -16,7 +16,7 @@ var Exchange = require('./exchange');
 var Queue = require('./queue');
 var AMQPParser = require('./parser');
 var nodeAMQPVersion = require('../package').version;
-    
+
 var maxFrameBuffer = 131072; // 128k, same as rabbitmq (which was
                              // copying qpid)
 
@@ -60,15 +60,18 @@ var Connection = module.exports = function Connection (connectionArgs, options, 
   EventEmitter.call(this);
   this.setOptions(connectionArgs);
   this.setImplOptions(options);
-  
+
   if (typeof readyCallback === 'function') {
     this._readyCallback = readyCallback;
   }
-  
+
   this.connectionAttemptScheduled = false;
   this._defaultExchange = null;
   this.channelCounter = 0;
   this._sendBuffer = new Buffer(maxFrameBuffer);
+
+  this._blocked = false;
+  this._blockedReason = null;
 };
 util.inherits(Connection, EventEmitter);
 
@@ -495,6 +498,20 @@ Connection.prototype._onMethod = function (channel, method, args) {
       this.socket.end();
       break;
 
+    case methods.connectionBlocked:
+      debug && debug('Received connection.blocked from server with reason: ' + args.reason);
+      this._blocked = true;
+      this._blockedReason = args.reason;
+      this.emit('blocked');
+      break;
+
+    case methods.connectionUnblocked:
+      debug && debug('Received connection.unblocked from server');
+      this._blocked = false;
+      this._blockedReason = null;
+      this.emit('unblocked');
+      break;
+
     default:
       throw new Error("Uncaught method '" + method.name + "' with args " +
           JSON.stringify(args));
@@ -528,7 +545,7 @@ Connection.prototype._parseURLOptions = function(connectionString) {
 /*
  *
  * Connect helpers
- * 
+ *
  */
 
 // If you pass a array of hosts, lets choose a random host or the preferred host number, or then next one.
@@ -536,13 +553,13 @@ Connection.prototype._chooseHost = function() {
   if(Array.isArray(this.options.host)){
     if(this.hosti == null){
       if(typeof this.options.hostPreference == 'number') {
-        this.hosti = (this.options.hostPreference < this.options.host.length) ? 
-          this.options.hostPreference : this.options.host.length-1; 
-      } else {   
+        this.hosti = (this.options.hostPreference < this.options.host.length) ?
+          this.options.hostPreference : this.options.host.length-1;
+      } else {
         this.hosti = parseInt(Math.random() * this.options.host.length, 10);
       }
     } else {
-      // If this is already set, it looks like we want to choose another one. 
+      // If this is already set, it looks like we want to choose another one.
       // Add one to hosti but don't overflow it.
       this.hosti = (this.hosti + 1) % this.options.host.length;
     }
@@ -635,7 +652,7 @@ Connection.prototype._startHandshake = function() {
 /*
  *
  * Parse helpers
- * 
+ *
  */
 
 Connection.prototype._sendBody = function (channel, body, properties) {

--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -212,6 +212,14 @@ Exchange.prototype._onMethod = function (channel, method, args) {
 Exchange.prototype.publish = function (routingKey, data, options, callback) {
   var self = this;
 
+  if (this.connection._blocked) {
+    if (callback) {
+      return callback(true, new Error('Connection is blocked, server reason: ' + this.connection._blockedReason));
+    } else {
+      return;
+    }
+  }
+
   options = _.extend({}, options || {});
   options.routingKey = routingKey;
   options.exchange   = self.name;

--- a/test/test-connection-blocked.js
+++ b/test/test-connection-blocked.js
@@ -1,0 +1,61 @@
+var harness = require('./harness');
+var sys = require('sys');
+var exec = require('child_process').exec;
+
+if (typeof(options.clientProperties) === 'undefined') {
+  options.clientProperties = {};
+}
+if (typeof(options.clientProperties.capabilities) === 'undefined') {
+  options.clientProperties.capabilities = {};
+}
+options.clientProperties.capabilities['connection.blocked'] = true;
+
+var connection = harness.run();
+var exchange;
+
+var blockedCnt = 0;
+var unblockedCnt = 0;
+var errorWhenBlocked = false;
+
+var finishTimeout = setTimeout(function() {
+    //console.log('!!!fired!!!');
+    connection.end();
+}, 10000);
+
+connection.once('ready', function() {
+    exchange = connection.exchange('node-connection-blocked', {
+        autoDelete: true
+    }, function(exchange) {
+        exec('rabbitmqctl set_vm_memory_high_watermark 0', function(err, stdout, stderr) {
+            exchange.publish("", "hello");
+        });
+    });
+});
+
+connection.on('blocked', function() {
+    //console.log('!blocked');
+    blockedCnt++;
+
+    exchange.publish("", "hello", {}, function(isErr, err) {
+        if (isErr && err) {
+            errorWhenBlocked = true;
+        }
+        exec('rabbitmqctl set_vm_memory_high_watermark 0.4');
+    });
+});
+
+connection.on('unblocked', function() {
+    //console.log('!unblocked');
+
+    unblockedCnt++;
+    clearTimeout(finishTimeout);
+    connection.end();
+});
+
+process.addListener('exit', function() {
+    exec('rabbitmqctl set_vm_memory_high_watermark 0.4');
+
+    assert.equal(1, blockedCnt);
+    assert.equal(1, unblockedCnt);
+    assert.equal(true, errorWhenBlocked);
+});


### PR DESCRIPTION
I have added support for blocked connection notifications (http://www.rabbitmq.com/connection-blocked.html)

1) When server sends connection.blocked / connection.unblocked an event is emited by Connection object, and the information about being blocked is saved.
2) When someone try to publish to an exchange through blocked connection and callback is provided it returns an error.

I'm not sure if the test case I provided is ok for you, because the only way (AFAIK) to easily simulate desired state is to set vm_memory_high_watermark to 0 using rabbitmqctl. Although it proves that both above works, it might be problematic for someone (or travis etc.) to use rabbitmqctl which often needs root account.

More, if you don't want publishers to fail with error when connection is blocked it is still good for me just to have event emitted from Connection object.