### PR TITLE
negotiate channelMax with the server

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -19,7 +19,7 @@ var nodeAMQPVersion = require('../package').version;
     
 var maxFrameBuffer = 131072; // 128k, same as rabbitmq (which was
                              // copying qpid)
-
+var channelMax = 65536;
 var defaultPorts = { 'amqp': 5672, 'amqps': 5671 };
 
 var defaultOptions = {
@@ -453,9 +453,13 @@ Connection.prototype._onMethod = function (channel, method, args) {
           debug && debug("tweaking maxFrameBuffer to " + args.frameMax);
           maxFrameBuffer = args.frameMax;
       }
+      if (args.channelMax) {
+          debug && debug("tweaking channelMax to " + args.channelMax);
+          channelMax = args.channelMax;
+      }
       // 5. We respond with connectionTuneOk
       this._sendMethod(0, methods.connectionTuneOk, {
-        channelMax: 0,
+        channelMax: channelMax,
         frameMax: maxFrameBuffer,
         heartbeat: this.options.heartbeat || 0
       });
@@ -789,7 +793,7 @@ Connection.prototype.generateChannelId = function () {
   var channelId = this.channelCounter;
   while(true){
     // use values in range of 1..65535
-    channelId = channelId % 65535 + 1;
+    channelId = channelId % channelMax + 1;
     if(!this.channels[channelId]){
       break;
     }


### PR DESCRIPTION
Very important for upcoming RabbitMQ 3.3.5, that will close connections that don't respect the channelMax set by the server. 