### PR TITLE
Set confirm.select to pre-baked exchanges as well

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -48,6 +48,12 @@ Exchange.prototype._onMethod = function (channel, method, args) {
     case methods.channelOpenOk:
       // Pre-baked exchanges don't need to be declared
       if (/^$|(amq\.)/.test(this.name)) {
+        //If confirm mode is specified we have to set it no matter the exchange.
+        if (this.options.confirm) {
+          this.connection._sendMethod(channel, methods.confirmSelect, { noWait: false });
+          return;
+        }
+
         this.state = 'open';
         // - issue #33 fix
         if (this._openCallback) {


### PR DESCRIPTION
confirm.select applies to the channel and NOT to the exchange so we have
to set it even for pre-backed exhcanges.

This patch sends the confirmSelect method if the confirm option is set
meaning that the open event (or the callback) will not happen until
confirmSelectOk is received.

This fixes being able to use confirm with default exchanges.