### PR TITLE
README.md: update doc to match default connectionTimeout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ objects as parameters.  The first options object has these defaults:
     , port: 5672
     , login: 'guest'
     , password: 'guest'
-    , connectionTimeout: 0,
+    , connectionTimeout: 10000,
     , authMechanism: 'AMQPLAIN'
     , vhost: '/'
     , noDelay: true


### PR DESCRIPTION
lib/connection.js:32 shows that the default connection timeout
is 10000, yet the README.md states that it's 0. Update the docs
to match the value in the code.