### PR TITLE
Avoid removing exchange (cleanup) on queue destroy

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -354,7 +354,6 @@ Queue.prototype.destroy = function (options) {
     self.connection.queueClosed(self.name);
     if ('exchange' in self) {
       self.exchange.binds--;
-      self.exchange.cleanup();
     }
     self.connection._sendMethod(self.channel, methods.queueDelete,
         { reserved1: 0


### PR DESCRIPTION
The scenario is the following: I create exchange `e1`, create queue `q1` and add a binding between the two. If I destroy the queue, the bindings count for the exchange will be 0 and the exchange will call `connection.exchangeClosed` which then deletes the exchange from `connection.exchanges`. The exchange hasn't been really closed, and obviously trying to `connection.exchanges['e1'].publish` will result in an error.

Even if the queue is deleted, it should be still possible to use the exchange and publish messages to it. The exchange may be bound to another queue in another application, etc.