### PR TITLE
channel_max can't be more than 65535 (0xffff)

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -19,7 +19,7 @@ var nodeAMQPVersion = require('../package').version;
 
 var maxFrameBuffer = 131072; // 128k, same as rabbitmq (which was
                              // copying qpid)
-var channelMax = 65536;
+var channelMax = 65535;
 var defaultPorts = { 'amqp': 5672, 'amqps': 5671 };
 
 var defaultOptions = {


### PR DESCRIPTION
Fixes an off-by-one bug in #350 