### PR TITLE
Remove the useless comma at Connection options part in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ objects as parameters.  The first options object has these defaults:
     , port: 5672
     , login: 'guest'
     , password: 'guest'
-    , connectionTimeout: 10000,
+    , connectionTimeout: 10000
     , authMechanism: 'AMQPLAIN'
     , vhost: '/'
     , noDelay: true


### PR DESCRIPTION
The comma is duplicated. So it will not work as a sample in README.md.

Please remove it.

Thanks.