### PR TITLE
Issue 385: Adjust maxFrameBuffer of the AMQPParser

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -471,6 +471,8 @@ Connection.prototype._onMethod = function (channel, method, args) {
       if (args.frameMax) {
           debug && debug("tweaking maxFrameBuffer to " + args.frameMax);
           maxFrameBuffer = args.frameMax;
+          this._sendBuffer = new Buffer(maxFrameBuffer);
+          this.parser.setMaxFrameBuffer(maxFrameBuffer);
       }
       if (args.channelMax) {
           debug && debug("tweaking channelMax to " + args.channelMax);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -16,7 +16,7 @@ var classes = definitions.classes;
 
 // parser
 
-var maxFrameBuffer = 131072; // 128k, same as rabbitmq (which was
+var MAX_FRAME_BUFFER_DEFAULT = 131072; // 128k, same as rabbitmq (which was
                              // copying qpid)
 
 // An interruptible AMQP parser.
@@ -36,6 +36,7 @@ var maxFrameBuffer = 131072; // 128k, same as rabbitmq (which was
 var AMQPParser = module.exports = function AMQPParser (version, type) {
   this.isClient = (type == 'client');
   this.state = this.isClient ? 'frameHeader' : 'protocolHeader';
+  this.maxFrameBuffer = MAX_FRAME_BUFFER_DEFAULT;
 
   if (version != '0-9-1') this.throwError("Unsupported protocol version");
 
@@ -56,7 +57,7 @@ var AMQPParser = module.exports = function AMQPParser (version, type) {
       frameChannel = parseInt(fh, 2);
       var frameSize = parseInt(fh, 4);
       fh.used = 0; // for reuse
-      if (frameSize > maxFrameBuffer) {
+      if (frameSize > self.maxFrameBuffer) {
         self.throwError("Oversized frame " + frameSize);
       }
       frameBuffer = new Buffer(frameSize);
@@ -137,6 +138,16 @@ AMQPParser.prototype.execute = function (data) {
   this.parse = this.parse(data);
 };
 
+/**
+ * Set the maximum frame buffer size in bytes. The connection needs to change this
+ * if the server responds with a connection tune event where the maxFrameBuffer
+ * was changed in the server config.
+ *
+ * @param maxFrameBuffer the maximum frame buffer size in bytes
+ */
+AMQPParser.prototype.setMaxFrameBuffer = function(maxFrameBuffer) {
+  this.maxFrameBuffer = maxFrameBuffer;
+};
 
 // parse Network Byte Order integers. size can be 1,2,4,8
 function parseInt (buffer, size) {


### PR DESCRIPTION
Node version: 0.12.0
RabbitMQ Version: 3.4.2

I have to send messages with a frame size greater than the default. But setting the frame_max within the rabbit configuration only changes the maxFrameBuffer of the Connection class in connection.js. This leads to a situation where I can send big messages but cannot receive them because of an Frame Oversize error.

This commit implements a setter on the AMQPParser for adjusting the maxFrameBuffer value. 

There are broken tests, but they are broken without my commit anyway. 