### PR TITLE
Correctly handle void values in AMQP packages

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -11,7 +11,7 @@ module.exports = {
     , SIGNED_64BIT: 'l'.charCodeAt(0)
     , _32BIT_FLOAT: 'f'.charCodeAt(0)
     , _64BIT_FLOAT: 'd'.charCodeAt(0)
-    , VOID:         'v'.charCodeAt(0)
+    , VOID:         'V'.charCodeAt(0)
     , BYTE_ARRAY:   'x'.charCodeAt(0)
     , ARRAY:        'A'.charCodeAt(0)
     , TEN:          '10'.charCodeAt(0)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -246,6 +246,9 @@ function parseValue (buffer) {
 
       return arr;
 
+    case AMQPTypes.VOID:
+      return null;
+
     default:
       throw new Error("Unknown field value type " + buffer[buffer.read-1]);
   }


### PR DESCRIPTION
In the current implementation, a Void type is default (as `v`), but if it is encountered by `parseValue`, an error is thrown. The Void type is also mis-defined as a lowercase `v`. We observed this error in production environments, and it appears that Void is `V` -- http://www.rabbitmq.com/amqp-0-9-1-errata.html#section_3