### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,7 @@
   }
 , "main" : "./amqp"
 , "engines" : { "node" : "0.4 || 0.6 || 0.8 || 0.9 || 0.10 || 0.11 || 0.12" }
-, "licenses" :
-  [ { "type" : "MIT"
-    , "url" : "http://github.com/postwait/node-amqp/raw/master/LICENSE-MIT"
-    }
-  ]
+, "license" : "MIT"
 , "dependencies" : 
   {
     "lodash": "~1.3.1"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/