### PR TITLE
Don't allow publishing to an exchange that is not open.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -353,8 +353,18 @@ Connection.prototype.queueClosed = function (name) {
 
 // Publishes a message to the default exchange.
 Connection.prototype.publish = function (routingKey, body, options, callback) {
-  if (!this._defaultExchange) this._defaultExchange = this.exchange();
-  return this._defaultExchange.publish(routingKey, body, options, callback);
+  if (!this._defaultExchange) {
+    this._defaultExchange = this.exchange();
+  }
+
+  var exchange = this._defaultExchange;
+  if (exchange.state === 'open') {
+    exchange.publish(routingKey, body, options, callback);
+  } else {
+    exchange.once('open', function() {
+      exchange.publish(routingKey, body, options, callback);
+    });
+  }
 };
 
 Connection.prototype._bodyToBuffer = function (body) {
@@ -671,7 +681,7 @@ Connection.prototype.end = function() {
 Connection.prototype._getSSLOptions = function() {
   if (this.sslConnectionOptions) return this.sslConnectionOptions;
   this.sslConnectionOptions = {};
-  
+
   if (this.options.ssl.pfxFile) {
     this.sslConnectionOptions.pfx = fs.readFileSync(this.options.ssl.pfxFile);
   }
@@ -690,10 +700,10 @@ Connection.prototype._getSSLOptions = function() {
       this.sslConnectionOptions.ca = fs.readFileSync(this.options.ssl.caFile);
     }
   }
-  
+
   this.sslConnectionOptions.rejectUnauthorized = this.options.ssl.rejectUnauthorized;
   this.sslConnectionOptions.passphrase = this.options.ssl.passphrase;
-  
+
   return this.sslConnectionOptions;
 };
 

--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -7,6 +7,7 @@ var fs = require('fs');
 var _ = require('lodash');
 var methods = require('./definitions').methods;
 var Channel = require('./channel');
+var debug = require('./debug');
 
 var Exchange = module.exports = function Exchange (connection, channel, name, options, openCallback) {
   Channel.call(this, connection, channel);
@@ -28,13 +29,14 @@ function createExchangeErrorHandlerFor (exchange) {
   return function (err) {
     if (!exchange.options.confirm) return;
 
+    debug && debug('Exchange error handler triggered, erroring and wiping all unacked publishes');
     for (var id in exchange._unAcked) {
       var task = exchange._unAcked[id];
       task.emit('ack error', err);
       delete exchange._unAcked[id];
     }
-  }
-};
+  };
+}
 
 Exchange.prototype._onMethod = function (channel, method, args) {
   this.emit(method.name, args);
@@ -158,6 +160,7 @@ Exchange.prototype._onMethod = function (channel, method, args) {
     case methods.basicAck:
       this.emit('basic-ack', args);
       var sequenceNumber = args.deliveryTag.readUInt32BE(4), tag;
+      debug && debug("basic-ack, sequence: ", sequenceNumber);
 
       if (sequenceNumber === 0 && args.multiple === true) {
         // we must ack everything
@@ -271,6 +274,7 @@ Exchange.prototype._awaitConfirm = function _awaitConfirm (task, callback) {
     this._addedExchangeErrorHandler = true;
   }
 
+  debug && debug('awaiting confirmation for ' + this._sequence);
   task.sequence = this._sequence;
   this._unAcked[this._sequence] = task;
   this._sequence++;

--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -29,6 +29,8 @@ function createExchangeErrorHandlerFor (exchange) {
   return function (err) {
     if (!exchange.options.confirm) return;
 
+    // should requeue instead?
+    // https://www.rabbitmq.com/reliability.html#producer
     debug && debug('Exchange error handler triggered, erroring and wiping all unacked publishes');
     for (var id in exchange._unAcked) {
       var task = exchange._unAcked[id];
@@ -48,11 +50,20 @@ Exchange.prototype._onMethod = function (channel, method, args) {
 
   switch (method) {
     case methods.channelOpenOk:
+      this._sequence = null;
+
+      if (!this._addedExchangeErrorHandler) {
+        var errorHandler = createExchangeErrorHandlerFor(this);
+        this.connection.on('error', errorHandler);
+        this.on('error', errorHandler);
+        this._addedExchangeErrorHandler = true;
+      }
+
       // Pre-baked exchanges don't need to be declared
       if (/^$|(amq\.)/.test(this.name)) {
         //If confirm mode is specified we have to set it no matter the exchange.
         if (this.options.confirm) {
-          this.connection._sendMethod(channel, methods.confirmSelect, { noWait: false });
+          this._confirmSelect(channel);
           return;
         }
 
@@ -69,23 +80,7 @@ Exchange.prototype._onMethod = function (channel, method, args) {
       // we dont care if all of the options match.
       } else if (this.options.noDeclare) {
         if (this.options.confirm) {
-          this.connection._sendMethod(channel, methods.confirmSelect,
-            { noWait: false });
-          // We should wait for the confirmSelectOk message to come back
-          // before we consider the exchange open and fire the open callback.
-          // the handler for confirmSelectOk initializes this._sequence.
-          // whose values are used to match published messages with their
-	  // confirmations.  If we fired the open callback here, publishes
-          // could happen before that intialization.  If this happens,
-          // the first message gets a null value set as its "sequence" value
-          // but the ack comes back with a 1.  The 1 doesn't match anything
-          // in the array of messages awaiting confirmation, and so the
-          // confirmation doesn't do anything and the callback passed into
-          // the publish method never fires.  I've not full investigated, but
-          // presumably any message publishes that are performed before
-          // confirmSelectOk is received would have their confirmation
-          // behave abnormally.  
-	} else {
+          this._confirmSelect(channel);
           this.state = 'open';
 
           if (this._openCallback) {
@@ -113,11 +108,9 @@ Exchange.prototype._onMethod = function (channel, method, args) {
       }
       break;
 
-     case methods.exchangeDeclareOk:
-
+    case methods.exchangeDeclareOk:
       if (this.options.confirm) {
-        this.connection._sendMethod(channel, methods.confirmSelect,
-          { noWait: false });
+        this._confirmSelect(channel);
       } else {
 
         this.state = 'open';
@@ -127,7 +120,6 @@ Exchange.prototype._onMethod = function (channel, method, args) {
           this._openCallback = null;
         }
       }
-
       break;
 
     case methods.confirmSelectOk:
@@ -235,13 +227,19 @@ Exchange.prototype._onMethod = function (channel, method, args) {
 
 Exchange.prototype.publish = function (routingKey, data, options, callback) {
   var self = this;
+  callback = callback || function() {};
 
   if (this.connection._blocked) {
-    if (callback) {
-      return callback(true, new Error('Connection is blocked, server reason: ' + this.connection._blockedReason));
-    } else {
-      return;
-    }
+    return callback(true, new Error('Connection is blocked, server reason: ' + this.connection._blockedReason));
+  }
+
+  if (this.state !== 'open') {
+    this._sequence = null;
+    return callback(true, new Error('Can not publish to a closed exchange'));
+  }
+
+  if (this.options.confirm && !this._readyToPublishWithConfirms()) {
+    return callback(true, new Error('Not yet ready to publish with confirms'));
   }
 
   options = _.extend({}, options || {});
@@ -270,6 +268,8 @@ Exchange.prototype.publish = function (routingKey, data, options, callback) {
 // registers tasks for confirms
 Exchange.prototype._awaitConfirm = function _awaitConfirm (task, callback) {
   if (!this._addedExchangeErrorHandler) {
+    // if connection fails, we want to ack error all unacked publishes.
+    this.connection.on('error', createExchangeErrorHandlerFor(this));
     this.on('error', createExchangeErrorHandlerFor(this));
     this._addedExchangeErrorHandler = true;
   }
@@ -416,3 +416,12 @@ Exchange.prototype.bind_headers = function (/* exchange, routing [, bindCallback
         , "arguments": routing
     });
 };
+
+Exchange.prototype._confirmSelect = function(channel) {
+  this.connection._sendMethod(channel, methods.confirmSelect, { noWait: false });
+};
+
+Exchange.prototype._readyToPublishWithConfirms = function() {
+  return this._sequence != null;
+};
+

--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -235,7 +235,7 @@ Exchange.prototype.publish = function (routingKey, data, options, callback) {
 
   if (this.state !== 'open') {
     this._sequence = null;
-    return callback(true, new Error('Can not publish to a closed exchange'));
+    return callback(true, new Error('Can not publish: exchange is not open'));
   }
 
   if (this.options.confirm && !this._readyToPublishWithConfirms()) {

--- a/test/test-default-exchange.js
+++ b/test/test-default-exchange.js
@@ -8,7 +8,7 @@ connection.addListener('ready', function () {
 
   var q = connection.queue('node-default-exchange', function() {
     q.bind("#"); // bind to queue
-    
+
     q.on('queueBindOk', function() { // wait until queue is bound
       q.on('basicConsumeOk', function () { // wait until consumer is registered
         puts("publishing 2 msg messages");
@@ -20,7 +20,7 @@ connection.addListener('ready', function () {
           connection.end();
         }, 1000);
       });
-      
+
       q.subscribe({ routingKeyInPayload: true },
                   function (msg) { // register consumer
         recvCount++;

--- a/test/test-exchange-publish-closed.js
+++ b/test/test-exchange-publish-closed.js
@@ -1,0 +1,20 @@
+require('./harness').run();
+
+connection.addListener('ready', function () {
+  puts("connected to " + connection.serverProperties.product);
+
+  var error;
+  var exchange = connection.exchange('node-simple-fanout', {type: 'fanout'});
+  exchange.publish('foo', 'data', {}, function(errored, err) {
+    assert.ok(errored);
+    error = err;
+
+    setTimeout(function() {
+      assert.equal(error.message, 'Can not publish: exchange is not open');
+      connection.end();
+      connection.destroy();
+      process.exit();
+    }, 1000);
+  });
+});
+

--- a/test/test-publish-confirms-callbacks-not-hanging-after-recovery.js
+++ b/test/test-publish-confirms-callbacks-not-hanging-after-recovery.js
@@ -1,0 +1,83 @@
+var assert = require('assert');
+var amqp = require('../amqp');
+var exec = require('child_process').exec;
+
+var cycleServer = function (stoppedCallback, startedCallback) {
+  // If you're running a cluster you can do this:
+  // 'killall -9 beam.smp'
+  // to test out hard server fails.  Note however that you probably do want a
+  // cluster because killing a single server this way causes even durable
+  // queues to be deleted, causing the bindings we create to be removed.
+  exec('rabbitmqctl stop_app', function () {
+    if (stoppedCallback) {
+      stoppedCallback();
+    }
+    setTimeout(function () {
+      // Likewise you can bring up a hard server crash this way:
+      // 'rabbitmq-server -detached'
+      exec('rabbitmqctl start_app', function () {
+        console.log('start triggered');
+        if (startedCallback) {
+          setTimeout(startedCallback, 500);
+        }
+      });
+    // Leave the server down for 1500ms before restarting.
+    }, 1500);
+  });
+};
+
+var connection, exchange;
+var timeout = null, didntHang = false, confirmed = 0, erroredAfterShutdown = 0;
+
+
+exec('which rabbitmqctl', function(err) {
+  if (err != null) {
+    console.log('skipping test, rabbitmqctl not availabe');
+    process.exit(0);
+  }
+
+  connection = amqp.createConnection(global.options || {}, { reconnect: true, reconnectBackoffTime: 500 }, function(connection) {
+    exchange = connection.exchange('node-publish-confirms', { type: 'fanout', confirm: true }, function(exchange) {
+      // publishing right before thhe server is stopped; must not "hang".
+      exchange.publish("", "hello", {}, function() {
+        console.log('callback fired for a message published right before the shutdown');
+        didntHang = true;
+      });
+      cycleServer(function() {
+        console.log('server stopped');
+        var incErrored = function(err) { console.log('received ack error'); if (err) { erroredAfterShutdown++; } };
+        exchange.publish("", "hello", {}, incErrored);
+        exchange.publish("", "hello", {}, incErrored);
+        exchange.publish("", "hello", {}, incErrored);
+      }, function() {
+        console.log('server started');
+        exchange.publish("", "hello2", {}, function() {   // this one must not "hang"
+          console.log('acked');
+          confirmed++;
+          clearTimeout(timeout);
+          connection.end();
+        });
+      });
+    });
+  });
+
+  timeout = setTimeout(function() {
+    process.exit();
+  }, 15000);
+
+  process.on('exit', function(){
+    try {
+      assert(didntHang);
+      assert.equal(erroredAfterShutdown, 3);
+      assert.equal(confirmed, 1);
+    } finally {
+      if (exchange) {
+        exchange.destroy();
+      }
+      if (connection) {
+        connection.setImplOptions({ 'reconnect': false });
+        connection.destroy();
+      }
+    }
+  });
+});

--- a/test/test-unbind.js
+++ b/test/test-unbind.js
@@ -25,7 +25,7 @@ conn.once('ready', function () {
     later(function(){
       // This will emit a NOT_FOUND error b/c we're no longer bound to the exchange
       var thrown = false;
-      conn.addListener('error', function(e){
+      exchange.addListener('error', function(e){
         thrown = true;
         assert.equal(e.code, 404);
       });


### PR DESCRIPTION
Prevents nasty issues like callbacks that are not fired when publisher confirmations are turned on, caused by broker-client acknowledgement sequencing mismatch.

Whenever a connection error occurs, if publisher confirmations are enabled, all currently unacked messages emit 'ack error' instead of not calling the callback altogether.

There also are two tests that don't pass for me on master, as well as on this branch.
```
test/test-connection-blocked.js:
assert.js:93
  throw new assert.AssertionError({
        ^
AssertionError: 1 == 0
    at process.<anonymous> (/Users/vlad/Projects/node-amqp/test/test-connection-blocked.js:58:12)
    at process.emit (events.js:95:17)
FAIL
```

```
test/test-flow.js:
/Users/vlad/Projects/node-amqp/node_modules/longjohn/dist/longjohn.js:195
        throw e;
              ^
Error: NOT_IMPLEMENTED - active=false
    at Connection._onMethod (/Users/vlad/Projects/node-amqp/lib/connection.js:518:15)
    at self.parser.onMethod (/Users/vlad/Projects/node-amqp/lib/connection.js:136:12)
    at AMQPParser._parseMethodFrame (/Users/vlad/Projects/node-amqp/lib/parser.js:366:10)
    at frameEnd (/Users/vlad/Projects/node-amqp/lib/parser.js:93:16)
    at frame (/Users/vlad/Projects/node-amqp/lib/parser.js:78:14)
    at header (/Users/vlad/Projects/node-amqp/lib/parser.js:64:14)
    at AMQPParser.execute (/Users/vlad/Projects/node-amqp/lib/parser.js:137:21)
    at Connection.<anonymous> (/Users/vlad/Projects/node-amqp/lib/connection.js:174:21)
    at Connection.emit (events.js:95:17)
---------------------------------------------
    at module.exports.run (/Users/vlad/Projects/node-amqp/test/harness.js:49:23)
    at Object.<anonymous> (/Users/vlad/Projects/node-amqp/test/test-flow.js:1:84)
    at Module._compile (module.js:456:26)
    at Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Module._load (module.js:312:12)
    at Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
FAIL
```