### PR TITLE
consumerTag name

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -42,7 +42,7 @@ Queue.prototype.subscribeRaw = function (options, messageListener) {
     options = {};
   }
 
-  var consumerTag = 'node-amqp-' + process.pid + '-' + Math.random();
+  var consumerTag = ['node', 'amqp', process.pid, require('os').hostname(), (Math.random()*10e6).toFixed()].join('-');
   this.consumerTagListeners[consumerTag] = messageListener;
 
   options = options || {};


### PR DESCRIPTION
I need consumer tag for logging purposes, this way I find it more informative.
addidionally added 
```
require('os').hostname()
```