### PR TITLE
Fix utf8 json

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -99,7 +99,7 @@ Exchange.prototype._onMethod = function (channel, method, args) {
             , type:       this.options.type || 'topic'
             , passive:    !!this.options.passive
             , durable:    !!this.options.durable
-            , auto_delete: !!this.options.autoDelete
+            , autoDelete: !!this.options.autoDelete
             , internal:   !!this.options.internal
             , noWait:     false
             , "arguments":this.options.arguments || {}
@@ -424,4 +424,3 @@ Exchange.prototype._confirmSelect = function(channel) {
 Exchange.prototype._readyToPublishWithConfirms = function() {
   return this._sequence != null;
 };
-

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,6 +1,7 @@
 'use strict';
 var util = require('util');
 var fs = require('fs');
+var StringDecoder = require('string_decoder').StringDecoder;
 var _ = require('lodash');
 var Channel = require('./channel');
 var Exchange = require('./exchange');
@@ -117,6 +118,7 @@ Queue.prototype.subscribe = function (options, messageListener) {
 
   return this.subscribeRaw(rawOptions, function (m) {
     var contentType = m.contentType;
+    var decoder = new StringDecoder('utf8');
 
     if (contentType == null && m.headers && m.headers.properties) {
       contentType = m.headers.properties.content_type;
@@ -138,7 +140,7 @@ Queue.prototype.subscribe = function (options, messageListener) {
 
     m.addListener('data', function (d) {
       if (isJSON) {
-        buffer += d.toString();
+        buffer += decoder.write(d);
       } else {
         d.copy(buffer, buffer.used);
         buffer.used += d.length;
@@ -149,6 +151,7 @@ Queue.prototype.subscribe = function (options, messageListener) {
       var json, deliveryInfo = {}, msgProperties = classes[60].fields, i, l;
 
       if (isJSON) {
+        decoder.end();
         try {
           json = JSON.parse(buffer);
         } catch (e) {

--- a/test/test-json.js
+++ b/test/test-json.js
@@ -11,13 +11,13 @@ connection.addListener('ready', function () {
   var q = connection.queue('node-json-queue', function() {
     var origMessage1 = {two:2, one:1},
         origMessage2 = {foo:'bar', hello: 'world'},
-        origMessage3 = {coffee:'caf\u00E9', tea: 'th\u00E9'};
+        origMessage3 = {coffee:'caf\u00E9', tea: 'th\u00E9', hearts: (new Array(50000)).join('❤')};
 
     q.bind(exchange, "*");
-  
+
     q.subscribe(function (json, headers, deliveryInfo) {
       recvCount++;
-  
+
       assert.equal("node-json-fanout", deliveryInfo.exchange);
       assert.equal("node-json-queue", deliveryInfo.queue);
       assert.equal(false, deliveryInfo.redelivered);
@@ -26,15 +26,15 @@ connection.addListener('ready', function () {
         case 'message.json1':
           assert.deepEqual(origMessage1, json);
           break;
-  
+
         case 'message.json2':
           assert.deepEqual(origMessage2, json);
           break;
-  
+
         case 'message.json3':
           assert.deepEqual(origMessage3, json);
           break;
-  
+
         default:
           throw new Error('unexpected routing key: ' + deliveryInfo.routingKey);
       }
@@ -44,7 +44,7 @@ connection.addListener('ready', function () {
       exchange.publish('message.json1', origMessage1);
       exchange.publish('message.json2', origMessage2, {contentType: 'application/json'});
       exchange.publish('message.json3', origMessage3, {contentType: 'application/json'});
-  
+
       setTimeout(function () {
         // wait one second to receive the message, then quit
         connection.end();


### PR DESCRIPTION
When receiving large data, `req.on('data', ...)` sometimes cuts UTF-8 characters off in the middle of the buffer.  
If you then cast the buffer to a string, you end up with broken characters in that string.
Use `StringDecoder` instead to make sure characters are correctly assembled again.

Also fixes an issue with a wrongly named `auto_delete` key that kept tests from running.