### PR TITLE
Add ability to force a reconnect on heartbeat timeout

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -397,8 +397,9 @@ Connection.prototype._inboundHeartbeatTimerReset = function () {
     var self = this;
     var gracePeriod = 2 * this.options.heartbeat;
     this._inboundHeartbeatTimer = setTimeout(function () {
-      if(self.socket.readable)
+      if(self.socket.readable || self.options.heartbeatForceReconnect){
         self.emit('error', new Error('no heartbeat or data in last ' + gracePeriod + ' seconds'));
+      }
     }, gracePeriod * 1000);
   }
 };


### PR DESCRIPTION
Introduces a heartbeatForceReconnect option, when true will force the library to reconnect on a heartbeat failure.

Looks like this is needed based on other issues and I needed it for a project as well.