### PR TITLE
Issue  #300: connection.end() causing ECONNRESET

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -529,6 +529,7 @@ Connection.prototype._onMethod = function (channel, method, args) {
     case methods.connectionCloseOk:
       debug && debug("Received close-ok from server, closing socket");
       this.socket.end();
+      this.socket.destroy();
       break;
 
     case methods.connectionBlocked:


### PR DESCRIPTION
To fix #300 as [suggested by glenjamin ](https://github.com/postwait/node-amqp/issues/300#issuecomment-33868395), this just adds `this.socket.destroy();` to the `connectionCloseOk` handler.