### PR TITLE
Added event hook when a consumer tag changes on reconnection (see #447)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lib/amqp/constants-generated.js
 node_modules/
 .DS_Store
+.idea

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -34,11 +34,12 @@ var Queue = module.exports = function Queue (connection, channel, name, options,
 };
 util.inherits(Queue, Channel);
 
-Queue.prototype.subscribeRaw = function (options, messageListener) {
+Queue.prototype.subscribeRaw = function (options, messageListener, oldConsumerTag) {
   var self = this;
 
   // multiple method signatures
   if (typeof options === "function") {
+    oldConsumerTag = messageListener;
     messageListener = options;
     options = {};
   }
@@ -56,6 +57,12 @@ Queue.prototype.subscribeRaw = function (options, messageListener) {
         , prefetchCount: options.prefetchCount
         , global: false
         });
+  }
+
+  // If this is a reconnection, we should probably tell folks their tag has changed
+  if (oldConsumerTag) {
+    debug && debug('Existing consumer tag changed', util.inspect({ oldConsumerTag: oldConsumerTag, consumerTag: consumerTag }));
+    self.connection.emit('tag.change', { oldConsumerTag: oldConsumerTag, consumerTag: consumerTag });
   }
 
   return this._taskPush(methods.basicConsumeOk, function () {
@@ -444,7 +451,7 @@ Queue.prototype._onMethod = function (channel, method, args) {
       for (var index in consumerTags) {
         if (consumerTags.hasOwnProperty(index)) {
           if (this.consumerTagOptions[consumerTags[index]]['state'] === 'closed') {
-            this.subscribeRaw(this.consumerTagOptions[consumerTags[index]], this.consumerTagListeners[consumerTags[index]]);
+            this.subscribeRaw(this.consumerTagOptions[consumerTags[index]], this.consumerTagListeners[consumerTags[index]], consumerTags[index]);
             // Having called subscribeRaw, we are now a new consumer with a new consumerTag.
             delete this.consumerTagListeners[consumerTags[index]];
             delete this.consumerTagOptions[consumerTags[index]];


### PR DESCRIPTION
Fixes the issue (#447) where the application is unable to act on the consumer after an error/reconnection. This hook allows the application to replace its consumerTag with the replacement value.

 * Queue#subscribeRaw now takes a third optional parameter `oldConsumerTag` which is used to indicate that this subscription is replacing an existing one
 * Connection#tag.change event – Fired when a consumerTag is replaced with a new value, so the application can update itself to know what it should unsubscribe from after the reconnection
 * gitignore for JetBrains IDE junk