### PR TITLE
fixed missing exchange open callbacks when noDeclare and no confirm

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -81,15 +81,17 @@ Exchange.prototype._onMethod = function (channel, method, args) {
       } else if (this.options.noDeclare) {
         if (this.options.confirm) {
           this._confirmSelect(channel);
-          this.state = 'open';
-
-          if (this._openCallback) {
-           this._openCallback(this);
-           this._openCallback = null;
-          }
-
-          this.emit('open');
+          return;
         }
+
+        this.state = 'open';
+
+        if (this._openCallback) {
+         this._openCallback(this);
+         this._openCallback = null;
+        }
+
+        this.emit('open');
       } else {
         this.connection._sendMethod(channel, methods.exchangeDeclare,
             { reserved1:  0

--- a/test/test-exchange-no-declare-and-no-confirm.js
+++ b/test/test-exchange-no-declare-and-no-confirm.js
@@ -1,0 +1,19 @@
+require('./harness').run();
+
+connection.addListener('ready', function () {
+  var callbackFired = false;
+
+  // first call to ensure exchange exists
+  connection.exchange('node-no-declare-and-confirm', {type: 'fanout'}, function () {
+
+    connection.exchange('node-no-declare-and-confirm', { noDeclare: true, confirm: false }, function (exchange) {
+      callbackFired = true;
+    });
+  });
+
+  setTimeout( function() {
+    assert.ok(callbackFired, "exchange not connected");
+    connection.end();
+    connection.destroy();
+  }, 1000);
+});


### PR DESCRIPTION
This pull request fixes bug that occurs when one try to connect to an exchange with `noDeclare: true` and `confirm: false`. With this set of options the `open` event has never been fired as well as open callback.