### PR TITLE
Parameterized consumerTag

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -44,7 +44,12 @@ Queue.prototype.subscribeRaw = function (options, messageListener, oldConsumerTa
     options = {};
   }
 
-  var consumerTag = 'node-amqp-' + process.pid + '-' + Math.random();
+  var consumerTag;
+  if (options.consumerTag !== undefined) {
+    consumerTag = options.consumerTag + '-' + Math.random();
+  } else {
+    consumerTag = 'node-amqp-' + process.pid + '-' + Math.random();
+  }
   this.consumerTagListeners[consumerTag] = messageListener;
 
   options = options || {};
@@ -121,6 +126,10 @@ Queue.prototype.subscribe = function (options, messageListener) {
 
   if (options.ack) {
     rawOptions['prefetchCount'] = options.prefetchCount;
+  }
+
+  if (options.consumerTag) {
+    rawOptions['consumerTag'] = options.consumerTag;
   }
 
   return this.subscribeRaw(rawOptions, function (m) {

--- a/test/test-consumer-tag.js
+++ b/test/test-consumer-tag.js
@@ -1,0 +1,14 @@
+require('./harness').run();
+
+var queueName = 'node-consumer-tag-test';
+var consumerTag = 'testingConsumerTag';
+
+connection.on('ready', function() {
+  var q = connection.queue(queueName, {autoDelete: false}, function() {
+    q.subscribe({consumerTag});
+
+    assert.ok(Object.keys(q.consumerTagOptions)[0].includes(consumerTag));
+    connection.end();
+  });
+});
+


### PR DESCRIPTION
Allows clients of this library to set their own `consumerTag` to easily recognize queue consumers in the Rabbit Dashboard UI