### PR TITLE
Allow routing key in header binding

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -307,21 +307,24 @@ Queue.prototype.unbind = function (exchange, routingKey) {
   });
 };
 
-Queue.prototype.bind_headers = function (/* [exchange,] matchingPairs */) {
+Queue.prototype.bind_headers = function (/* [exchange,] matchingPairs [, routingKey] */) {
   var self = this;
 
   // The first argument, exchange is optional.
   // If not supplied the connection will use the default 'amq.headers'
   // exchange.
+  // The third argument, routingKey is optional. If not supplied routingKey is an empty string 
 
-  var exchange, matchingPairs;
+  var exchange, routingKey, matchingPairs;
 
-  if (arguments.length == 2) {
+  if (arguments.length >= 2) {
     exchange = arguments[0];
     matchingPairs = arguments[1];
+    routingKey = arguments[2] || '';
   } else {
     exchange = 'amq.headers';
     matchingPairs = arguments[0];
+    routingKey = arguments[1] || '';
   }
 
 
@@ -331,7 +334,7 @@ Queue.prototype.bind_headers = function (/* [exchange,] matchingPairs */) {
         { reserved1: 0
         , queue: self.name
         , exchange: exchangeName
-        , routingKey: ''
+        , routingKey: routingKey
         , noWait: false
         , "arguments": matchingPairs
         });


### PR DESCRIPTION
Hi,  this is possible with other clients 

Do you know why you are setting the routing key in `bind_headers` to an empty string? 
Could you please accept this? 

Kind regards
Thami 